### PR TITLE
Handle already read response body stream

### DIFF
--- a/static/js/dicom_viewer.js
+++ b/static/js/dicom_viewer.js
@@ -309,11 +309,15 @@ class DicomViewer {
                 }, 1000);
             } else {
                 try {
+                    // Clone the response to avoid "body stream already read" error
+                    const responseClone = response.clone();
                     const errorData = await response.json();
                     throw new Error(errorData.error || 'Upload failed');
                 } catch (parseError) {
                     console.error('Failed to parse error response:', parseError);
-                    console.error('Response text:', await response.text());
+                    // Use the cloned response to read the text
+                    const responseText = await responseClone.text();
+                    console.error('Response text:', responseText);
                     throw new Error(`Server error (${response.status}). Please try again.`);
                 }
             }
@@ -391,11 +395,15 @@ class DicomViewer {
                 }, 1000);
             } else {
                 try {
+                    // Clone the response to avoid "body stream already read" error
+                    const responseClone = response.clone();
                     const errorData = await response.json();
                     throw new Error(errorData.error || 'Upload failed');
                 } catch (parseError) {
                     console.error('Failed to parse error response:', parseError);
-                    console.error('Response text:', await response.text());
+                    // Use the cloned response to read the text
+                    const responseText = await responseClone.text();
+                    console.error('Response text:', responseText);
                     throw new Error(`Server error (${response.status}). Please try again.`);
                 }
             }


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fix 'body stream already read' error by cloning `Response` object before reading its body multiple times.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
When a server response was not OK, the error handling attempted to parse the response as JSON and then, if that failed, tried to read the response text. Calling `response.json()` consumes the response body stream, making subsequent calls like `response.text()` on the same response fail. Cloning the response provides a separate stream for the second read attempt.

---

[Open in Web](https://cursor.com/agents?id=bc-36e89d23-da33-418d-a94f-518ebd0e45d0) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-36e89d23-da33-418d-a94f-518ebd0e45d0) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)