### PR TITLE
Fix undefined responseclone for upload

### DIFF
--- a/static/js/dicom_viewer.js
+++ b/static/js/dicom_viewer.js
@@ -316,9 +316,9 @@ class DicomViewer {
                     }
                 }, 1000);
             } else {
+                // Clone the response to avoid "body stream already read" error
+                const responseClone = response.clone();
                 try {
-                    // Clone the response to avoid "body stream already read" error
-                    const responseClone = response.clone();
                     const errorData = await response.json();
                     throw new Error(errorData.error || 'Upload failed');
                 } catch (parseError) {
@@ -402,9 +402,9 @@ class DicomViewer {
                     }
                 }, 1000);
             } else {
+                // Clone the response to avoid "body stream already read" error
+                const responseClone = response.clone();
                 try {
-                    // Clone the response to avoid "body stream already read" error
-                    const responseClone = response.clone();
                     const errorData = await response.json();
                     throw new Error(errorData.error || 'Upload failed');
                 } catch (parseError) {


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fix "responseClone is not defined" error during upload failures by moving its declaration outside the try block.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The `responseClone` variable was declared within the `try` block, meaning it was not accessible in the `catch` block if the `response.clone()` call itself failed, leading to a `ReferenceError`. Moving the declaration ensures it's always in scope for error handling.

---

[Open in Web](https://cursor.com/agents?id=bc-3281a9a5-964b-4316-84b8-f2b24b4d7396) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-3281a9a5-964b-4316-84b8-f2b24b4d7396) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)