### PR TITLE
Fix worklist upload and dicom viewer errors

### DIFF
--- a/worklist/views.py
+++ b/worklist/views.py
@@ -52,6 +52,13 @@ class WorklistView(LoginRequiredMixin, ListView):
         if modality:
             queryset = queryset.filter(modality=modality)
             
+        # Filter by facility if facility id provided in query params (used by dropdown)
+        facility_id = self.request.GET.get('facility')
+        if facility_id:
+            try:
+                queryset = queryset.filter(facility_id=int(facility_id))
+            except ValueError:
+                pass  # Ignore invalid facility ids
         return queryset
     
     def get_context_data(self, **kwargs):


### PR DESCRIPTION
Ensure uploaded studies appear in the worklist and enable facility filtering.

Previously, worklist entries were only created if a study was *newly* created during upload, leading to uploaded studies not appearing in the worklist. This PR updates the upload logic to always create or update a `WorklistEntry` for every successfully imported study, linking it and marking it as completed. This ensures studies are visible and viewable. Additionally, the worklist backend now correctly applies facility filtering based on the URL parameter.

---
<a href="https://cursor.com/background-agent?bcId=bc-f6d21273-7867-470d-b567-1aadc19f0f2e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f6d21273-7867-470d-b567-1aadc19f0f2e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>