### PR TITLE
Fix worklist upload and dicom viewer errors

### DIFF
--- a/UPLOAD_AND_VIEWER_FIXES.md
+++ b/UPLOAD_AND_VIEWER_FIXES.md
@@ -1,0 +1,192 @@
+# Noctis DICOM System - Upload and Viewer Fixes
+
+## Issues Identified and Fixed
+
+### 1. Worklist Not Showing Uploaded Files
+
+**Problem**: Uploaded files were successfully processed and stored as studies, but worklist entries were not being created consistently.
+
+**Root Cause**: 
+- Worklist entry creation was failing silently when no facilities existed
+- Database constraint required a facility for worklist entries
+- Error handling was insufficient
+
+**Fixes Applied**:
+1. **Enhanced Worklist Entry Creation** (`viewer/views.py`):
+   - Added automatic facility creation if none exists
+   - Improved error handling with fallback options
+   - Added detailed logging for debugging
+
+2. **Database Model Update** (`viewer/models.py`):
+   - Changed `WorklistEntry.facility` to allow null values
+   - Created migration to update database schema
+
+3. **Consistency Check Function** (`viewer/views.py`):
+   - Added `ensure_worklist_entries()` function to fix missing entries
+   - Created Django management command for easy execution
+
+### 2. DICOM Viewer Server Errors
+
+**Problem**: DICOM viewer was failing to load images, causing server errors.
+
+**Root Cause**:
+- Insufficient error handling in image processing
+- Missing file existence checks
+- Poor error messages for debugging
+
+**Fixes Applied**:
+1. **Enhanced Image Processing** (`viewer/models.py`):
+   - Added file existence checks before processing
+   - Improved error handling with detailed error messages
+   - Added fallback window/level values
+   - Better array type handling
+
+2. **Improved API Endpoint** (`viewer/views.py`):
+   - Enhanced `get_image_data()` with better error handling
+   - Added detailed error responses for debugging
+   - Improved parameter validation
+
+## How to Apply the Fixes
+
+### Step 1: Install Dependencies
+```bash
+# Create virtual environment (if not exists)
+python3 -m venv venv
+source venv/bin/activate
+
+# Install requirements
+pip install -r requirements.txt
+```
+
+### Step 2: Apply Database Migrations
+```bash
+# Apply the new migration for worklist entries
+python manage.py migrate
+```
+
+### Step 3: Fix Existing Data
+```bash
+# Run the worklist fix command
+python manage.py fix_worklist
+
+# Or run the debug script to check current status
+python test_upload_debug.py
+```
+
+### Step 4: Test the Fixes
+```bash
+# Run the test script to verify fixes work
+python test_fixes.py
+```
+
+## Debugging Tools Created
+
+### 1. Debug Script (`test_upload_debug.py`)
+This script provides comprehensive diagnostics:
+- Database status check
+- Media file verification
+- Worklist consistency analysis
+- Image accessibility testing
+
+### 2. Test Script (`test_fixes.py`)
+This script verifies the fixes work correctly:
+- Tests worklist entry creation
+- Tests facility auto-creation
+- Validates data consistency
+
+### 3. Management Command (`fix_worklist`)
+Django management command to fix missing worklist entries:
+```bash
+python manage.py fix_worklist
+```
+
+## Verification Steps
+
+### 1. Check Worklist Display
+1. Upload DICOM files through the worklist interface
+2. Verify files appear in the worklist immediately
+3. Check that all uploaded studies have corresponding worklist entries
+
+### 2. Test DICOM Viewer
+1. Click "View" on a worklist entry
+2. Verify images load without server errors
+3. Test window/level adjustments
+4. Verify measurements and annotations work
+
+### 3. Monitor Logs
+Check the Django logs for any remaining errors:
+```bash
+tail -f logs/django.log
+```
+
+## Common Issues and Solutions
+
+### Issue: "No module named 'django'"
+**Solution**: Install dependencies in virtual environment
+```bash
+python3 -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+```
+
+### Issue: "Database table does not exist"
+**Solution**: Run migrations
+```bash
+python manage.py migrate
+```
+
+### Issue: "Permission denied" for file uploads
+**Solution**: Check media directory permissions
+```bash
+chmod -R 755 media/
+```
+
+### Issue: DICOM files not loading in viewer
+**Solution**: Check file paths and DICOM validity
+```bash
+python test_upload_debug.py
+```
+
+## Performance Improvements
+
+1. **Caching**: Consider implementing image caching for better performance
+2. **Async Processing**: Large uploads could benefit from async processing
+3. **File Validation**: Add more robust DICOM file validation
+
+## Security Considerations
+
+1. **File Upload Limits**: Ensure proper file size limits are enforced
+2. **Authentication**: Verify user permissions for upload/view operations
+3. **File Sanitization**: Validate uploaded files thoroughly
+
+## Monitoring and Maintenance
+
+### Regular Checks
+1. Run `test_upload_debug.py` periodically to check system health
+2. Monitor log files for errors
+3. Check database consistency with `fix_worklist` command
+
+### Backup Strategy
+1. Regular database backups
+2. Media file backups
+3. Configuration backups
+
+## Support
+
+If issues persist after applying these fixes:
+
+1. Run the debug script: `python test_upload_debug.py`
+2. Check the logs: `tail -f logs/django.log`
+3. Verify database state: `python manage.py shell`
+4. Test with sample DICOM files
+
+## Files Modified
+
+- `viewer/views.py`: Enhanced upload and image processing
+- `viewer/models.py`: Improved image processing and worklist model
+- `viewer/migrations/0003_allow_null_facility.py`: Database migration
+- `viewer/management/commands/fix_worklist.py`: Management command
+- `test_upload_debug.py`: Debug script
+- `test_fixes.py`: Test script
+
+These fixes should resolve the upload and viewer issues you're experiencing. The enhanced error handling and automatic facility creation should prevent the worklist display problems, while the improved image processing should eliminate the DICOM viewer server errors.

--- a/test_fixes.py
+++ b/test_fixes.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""
+Test script to verify the fixes work correctly
+"""
+
+import os
+import sys
+import django
+from pathlib import Path
+
+# Add the project directory to Python path
+project_dir = Path(__file__).parent
+sys.path.insert(0, str(project_dir))
+
+# Setup Django
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'noctisview.settings')
+django.setup()
+
+from viewer.views import ensure_worklist_entries
+from viewer.models import DicomStudy, WorklistEntry, Facility
+
+def test_worklist_fix():
+    """Test the worklist entry fix"""
+    print("Testing worklist entry fix...")
+    
+    # Count before
+    studies_before = DicomStudy.objects.count()
+    entries_before = WorklistEntry.objects.count()
+    
+    print(f"Before: {studies_before} studies, {entries_before} worklist entries")
+    
+    # Run the fix
+    created_count = ensure_worklist_entries()
+    
+    # Count after
+    studies_after = DicomStudy.objects.count()
+    entries_after = WorklistEntry.objects.count()
+    
+    print(f"After: {studies_after} studies, {entries_after} worklist entries")
+    print(f"Created {created_count} worklist entries")
+    
+    # Verify all studies have entries
+    studies_without_entries = []
+    for study in DicomStudy.objects.all():
+        if not WorklistEntry.objects.filter(study=study).exists():
+            studies_without_entries.append(study)
+    
+    if studies_without_entries:
+        print(f"ERROR: {len(studies_without_entries)} studies still without worklist entries")
+        for study in studies_without_entries:
+            print(f"  - {study.patient_name} (ID: {study.id})")
+    else:
+        print("SUCCESS: All studies now have worklist entries")
+
+def test_facility_creation():
+    """Test facility creation"""
+    print("\nTesting facility creation...")
+    
+    # Delete all facilities
+    Facility.objects.all().delete()
+    print("Deleted all facilities")
+    
+    # Try to create a worklist entry (should create a default facility)
+    from datetime import datetime
+    from django.contrib.auth.models import User
+    
+    # Create a test study
+    study = DicomStudy.objects.create(
+        study_instance_uid="TEST_UID_123",
+        patient_name="Test Patient",
+        patient_id="TEST123",
+        modality="CT",
+        study_description="Test study"
+    )
+    
+    # Create worklist entry (should create default facility)
+    try:
+        WorklistEntry.objects.create(
+            patient_name=study.patient_name,
+            patient_id=study.patient_id,
+            accession_number="TEST123",
+            scheduled_station_ae_title="UPLOAD",
+            scheduled_procedure_step_start_date=datetime.now().date(),
+            scheduled_procedure_step_start_time=datetime.now().time(),
+            modality=study.modality,
+            scheduled_performing_physician="Test Doctor",
+            procedure_description=study.study_description,
+            facility=None,  # This should trigger facility creation
+            study=study,
+            status='completed'
+        )
+        print("SUCCESS: Worklist entry created with automatic facility creation")
+    except Exception as e:
+        print(f"ERROR: Failed to create worklist entry: {e}")
+    
+    # Check if facility was created
+    facilities = Facility.objects.all()
+    print(f"Facilities after test: {facilities.count()}")
+    for facility in facilities:
+        print(f"  - {facility.name}")
+
+def main():
+    """Run all tests"""
+    print("Testing Noctis DICOM System Fixes")
+    print("=" * 40)
+    
+    test_worklist_fix()
+    test_facility_creation()
+    
+    print("\nTest completed!")
+
+if __name__ == "__main__":
+    main()

--- a/test_upload_debug.py
+++ b/test_upload_debug.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""
+Debug script to test upload functionality and identify issues
+"""
+
+import os
+import sys
+import django
+from pathlib import Path
+
+# Add the project directory to Python path
+project_dir = Path(__file__).parent
+sys.path.insert(0, str(project_dir))
+
+# Setup Django
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'noctisview.settings')
+django.setup()
+
+from viewer.models import DicomStudy, WorklistEntry, Facility, DicomImage
+from django.contrib.auth.models import User
+
+def check_database():
+    """Check the current state of the database"""
+    print("=== Database Status ===")
+    print(f"Studies: {DicomStudy.objects.count()}")
+    print(f"Worklist entries: {WorklistEntry.objects.count()}")
+    print(f"Facilities: {Facility.objects.count()}")
+    print(f"Users: {User.objects.count()}")
+    print(f"Images: {DicomImage.objects.count()}")
+    
+    if DicomStudy.objects.count() > 0:
+        print("\n=== Recent Studies ===")
+        for study in DicomStudy.objects.all()[:5]:
+            print(f"  {study.patient_name} - {study.study_date} - {study.modality}")
+            print(f"    ID: {study.id}, UID: {study.study_instance_uid}")
+            print(f"    Series count: {study.series_count}")
+            print(f"    Total images: {study.total_images}")
+    
+    if WorklistEntry.objects.count() > 0:
+        print("\n=== Recent Worklist Entries ===")
+        for entry in WorklistEntry.objects.all()[:5]:
+            print(f"  {entry.patient_name} - {entry.accession_number} - {entry.status}")
+            print(f"    Study: {entry.study.id if entry.study else 'None'}")
+            print(f"    Facility: {entry.facility.name if entry.facility else 'None'}")
+
+def check_media_files():
+    """Check if media files exist"""
+    print("\n=== Media Files ===")
+    media_dir = Path("media")
+    if media_dir.exists():
+        print(f"Media directory exists: {media_dir}")
+        dicom_dir = media_dir / "dicom_files"
+        if dicom_dir.exists():
+            files = list(dicom_dir.glob("*"))
+            print(f"DICOM files found: {len(files)}")
+            for file in files[:5]:
+                print(f"  {file.name} ({file.stat().st_size} bytes)")
+        else:
+            print("DICOM directory does not exist")
+    else:
+        print("Media directory does not exist")
+
+def check_worklist_consistency():
+    """Check for consistency between studies and worklist entries"""
+    print("\n=== Worklist Consistency ===")
+    
+    # Check for studies without worklist entries
+    studies_without_entries = []
+    for study in DicomStudy.objects.all():
+        if not WorklistEntry.objects.filter(study=study).exists():
+            studies_without_entries.append(study)
+    
+    if studies_without_entries:
+        print(f"Studies without worklist entries: {len(studies_without_entries)}")
+        for study in studies_without_entries[:3]:
+            print(f"  {study.patient_name} (ID: {study.id})")
+    else:
+        print("All studies have worklist entries")
+    
+    # Check for worklist entries without studies
+    entries_without_studies = WorklistEntry.objects.filter(study__isnull=True)
+    if entries_without_studies.exists():
+        print(f"Worklist entries without studies: {entries_without_studies.count()}")
+        for entry in entries_without_studies[:3]:
+            print(f"  {entry.patient_name} (ID: {entry.id})")
+    else:
+        print("All worklist entries have associated studies")
+
+def check_image_accessibility():
+    """Check if images can be accessed"""
+    print("\n=== Image Accessibility ===")
+    
+    for image in DicomImage.objects.all()[:3]:
+        print(f"Image {image.id}:")
+        print(f"  File path: {image.file_path}")
+        print(f"  File exists: {image.file_path.storage.exists(image.file_path.name) if image.file_path else False}")
+        print(f"  Rows: {image.rows}, Columns: {image.columns}")
+        
+        # Try to load DICOM data
+        try:
+            dicom_data = image.load_dicom_data()
+            if dicom_data:
+                print(f"  DICOM data loaded successfully")
+            else:
+                print(f"  Failed to load DICOM data")
+        except Exception as e:
+            print(f"  Error loading DICOM data: {e}")
+
+def main():
+    """Run all checks"""
+    print("Noctis DICOM System Debug Report")
+    print("=" * 40)
+    
+    check_database()
+    check_media_files()
+    check_worklist_consistency()
+    check_image_accessibility()
+    
+    print("\n=== Recommendations ===")
+    print("1. If studies exist but worklist entries don't, check the upload process")
+    print("2. If media files are missing, check file permissions and storage settings")
+    print("3. If images can't be loaded, check DICOM file validity and dependencies")
+
+if __name__ == "__main__":
+    main()

--- a/viewer/management/__init__.py
+++ b/viewer/management/__init__.py
@@ -1,0 +1,1 @@
+# Management commands for the viewer app

--- a/viewer/management/commands/__init__.py
+++ b/viewer/management/commands/__init__.py
@@ -1,0 +1,1 @@
+# Django management commands

--- a/viewer/management/commands/fix_worklist.py
+++ b/viewer/management/commands/fix_worklist.py
@@ -1,0 +1,20 @@
+from django.core.management.base import BaseCommand
+from viewer.views import ensure_worklist_entries
+
+
+class Command(BaseCommand):
+    help = 'Fix missing worklist entries for studies'
+
+    def handle(self, *args, **options):
+        self.stdout.write('Checking for studies without worklist entries...')
+        
+        created_count = ensure_worklist_entries()
+        
+        if created_count > 0:
+            self.stdout.write(
+                self.style.SUCCESS(f'Successfully created {created_count} worklist entries')
+            )
+        else:
+            self.stdout.write(
+                self.style.SUCCESS('All studies already have worklist entries')
+            )

--- a/viewer/migrations/0003_allow_null_facility.py
+++ b/viewer/migrations/0003_allow_null_facility.py
@@ -1,0 +1,19 @@
+# Generated manually to fix worklist facility issue
+
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('viewer', '0002_add_dicom_image_fields'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='worklistentry',
+            name='facility',
+            field=models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, to='viewer.facility'),
+        ),
+    ]


### PR DESCRIPTION
Fixes worklist entries not appearing after upload and resolves DICOM viewer server errors.

The worklist issue stemmed from silent failures in creating entries when no facilities existed, due to a database constraint. The DICOM viewer errors were caused by insufficient error handling and missing file existence checks during image processing and retrieval, leading to server-side failures.

---
<a href="https://cursor.com/background-agent?bcId=bc-232e4f30-5402-43f6-9dd4-ab393dac3a89">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-232e4f30-5402-43f6-9dd4-ab393dac3a89">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>