### PR TITLE
Fix dicom viewer and report navigation

### DIFF
--- a/static/js/dicom_viewer.js
+++ b/static/js/dicom_viewer.js
@@ -324,7 +324,7 @@ class DicomViewer {
         progressText.textContent = `Uploading ${validFiles.length} files...`;
         
         try {
-            const response = await fetch('/api/upload/', {
+            const response = await fetch('/viewer/api/upload/', {
                 method: 'POST',
                 body: formData,
                 headers: {
@@ -465,7 +465,7 @@ class DicomViewer {
         progressText.textContent = `Uploading ${dicomFiles.length} DICOM files...`;
         
         try {
-            const response = await fetch('/api/upload-folder/', {
+            const response = await fetch('/viewer/api/upload-folder/', {
                 method: 'POST',
                 body: formData,
                 headers: {
@@ -554,7 +554,7 @@ class DicomViewer {
     
     async loadBackendStudies() {
         try {
-            const response = await fetch('/api/studies/');
+            const response = await fetch('/viewer/api/studies/');
             const studies = await response.json();
             
             const select = document.getElementById('backend-studies');
@@ -580,7 +580,7 @@ class DicomViewer {
     
     async loadStudy(studyId) {
         try {
-            const response = await fetch(`/api/studies/${studyId}/images/`);
+            const response = await fetch(`/viewer/api/studies/${studyId}/images/`);
             
             if (!response.ok) {
                 throw new Error(`HTTP ${response.status}: ${response.statusText}`);
@@ -623,7 +623,7 @@ class DicomViewer {
                 inverted: this.inverted
             });
             
-            const response = await fetch(`/api/images/${imageData.id}/data/?${params}`);
+            const response = await fetch(`/viewer/api/images/${imageData.id}/data/?${params}`);
             
             if (!response.ok) {
                 throw new Error(`HTTP ${response.status}: ${response.statusText}`);
@@ -1319,7 +1319,7 @@ class DicomViewer {
         };
         
         try {
-            const response = await fetch('/api/measurements/save/', {
+            const response = await fetch('/viewer/api/measurements/save/', {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
@@ -1347,7 +1347,7 @@ class DicomViewer {
         };
         
         try {
-            const response = await fetch('/api/annotations/save/', {
+            const response = await fetch('/viewer/api/annotations/save/', {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
@@ -1369,7 +1369,7 @@ class DicomViewer {
         if (!this.currentImage) return;
         
         try {
-            const response = await fetch(`/api/images/${this.currentImage.id}/measurements/`);
+            const response = await fetch(`/viewer/api/images/${this.currentImage.id}/measurements/`);
             this.measurements = await response.json();
             this.updateMeasurementsList();
         } catch (error) {
@@ -1381,7 +1381,7 @@ class DicomViewer {
         if (!this.currentImage) return;
         
         try {
-            const response = await fetch(`/api/images/${this.currentImage.id}/annotations/`);
+            const response = await fetch(`/viewer/api/images/${this.currentImage.id}/annotations/`);
             this.annotations = await response.json();
         } catch (error) {
             console.error('Error loading annotations:', error);
@@ -1449,7 +1449,7 @@ class DicomViewer {
         if (!this.currentImage) return;
         
         try {
-            const response = await fetch(`/api/images/${this.currentImage.id}/clear-measurements/`, {
+            const response = await fetch(`/viewer/api/images/${this.currentImage.id}/clear-measurements/`, {
                 method: 'DELETE',
                 headers: {
                     'X-CSRFToken': this.getCSRFToken()
@@ -1477,7 +1477,7 @@ class DicomViewer {
             y1: ellipseData.end.y
         };
         try {
-            const response = await fetch('/api/measurements/hu/', {
+            const response = await fetch('/viewer/api/measurements/hu/', {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
@@ -1673,7 +1673,7 @@ class DicomViewer {
         const resultsDiv = document.getElementById('ai-results');
         resultsDiv.innerHTML = '<div class="loading">Performing AI analysis...</div>';
         
-        fetch(`/api/images/${this.currentImage.id}/ai-analysis/`, {
+        fetch(`/viewer/api/images/${this.currentImage.id}/ai-analysis/`, {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
@@ -2132,7 +2132,7 @@ class DicomViewer {
             unit: measurement.unit || this.measurementUnit
         };
         
-        fetch('/api/measurements/save/', {
+        fetch('/viewer/api/measurements/save/', {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
@@ -2167,7 +2167,7 @@ class DicomViewer {
             unit: 'HU'
         };
         
-        fetch('/api/measurements/save/', {
+        fetch('/viewer/api/measurements/save/', {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
@@ -2211,7 +2211,7 @@ class DicomViewer {
             color: color
         };
         
-        fetch('/api/annotations/save/', {
+        fetch('/viewer/api/annotations/save/', {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
@@ -2285,7 +2285,7 @@ class DicomViewer {
     async loadStudyImages(studyId) {
         console.log('Loading study images for study:', studyId);
         try {
-            const response = await fetch(`/api/studies/${studyId}/images/`);
+            const response = await fetch(`/viewer/api/studies/${studyId}/images/`);
             
             if (!response.ok) {
                 let errorMessage;

--- a/templates/worklist/report.html
+++ b/templates/worklist/report.html
@@ -1,0 +1,426 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Noctis - Radiology Report</title>
+    {% load static %}
+    <link rel="stylesheet" href="{% static 'css/worklist.css' %}">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
+    <style>
+        .report-container {
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 20px;
+            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+        }
+        
+        .report-header {
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            color: white;
+            padding: 20px;
+            border-radius: 10px;
+            margin-bottom: 20px;
+        }
+        
+        .report-header h1 {
+            margin: 0;
+            font-size: 24px;
+        }
+        
+        .study-info {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+            gap: 15px;
+            margin-top: 15px;
+        }
+        
+        .info-item {
+            background: rgba(255, 255, 255, 0.1);
+            padding: 10px;
+            border-radius: 5px;
+        }
+        
+        .info-label {
+            font-weight: bold;
+            font-size: 12px;
+            text-transform: uppercase;
+            opacity: 0.8;
+        }
+        
+        .info-value {
+            font-size: 14px;
+            margin-top: 5px;
+        }
+        
+        .report-form {
+            background: white;
+            border-radius: 10px;
+            padding: 30px;
+            box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+        }
+        
+        .form-section {
+            margin-bottom: 30px;
+        }
+        
+        .form-section h3 {
+            color: #333;
+            border-bottom: 2px solid #667eea;
+            padding-bottom: 10px;
+            margin-bottom: 20px;
+        }
+        
+        .form-group {
+            margin-bottom: 20px;
+        }
+        
+        .form-group label {
+            display: block;
+            margin-bottom: 8px;
+            font-weight: 600;
+            color: #333;
+        }
+        
+        .form-control {
+            width: 100%;
+            padding: 12px;
+            border: 2px solid #e1e5e9;
+            border-radius: 8px;
+            font-size: 14px;
+            transition: border-color 0.3s ease;
+            font-family: inherit;
+        }
+        
+        .form-control:focus {
+            outline: none;
+            border-color: #667eea;
+            box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        }
+        
+        textarea.form-control {
+            min-height: 120px;
+            resize: vertical;
+        }
+        
+        .btn {
+            padding: 12px 24px;
+            border: none;
+            border-radius: 8px;
+            font-size: 14px;
+            font-weight: 600;
+            cursor: pointer;
+            transition: all 0.3s ease;
+            text-decoration: none;
+            display: inline-block;
+            margin-right: 10px;
+        }
+        
+        .btn-primary {
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            color: white;
+        }
+        
+        .btn-primary:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 4px 12px rgba(102, 126, 234, 0.4);
+        }
+        
+        .btn-secondary {
+            background: #6c757d;
+            color: white;
+        }
+        
+        .btn-secondary:hover {
+            background: #5a6268;
+        }
+        
+        .btn-success {
+            background: #28a745;
+            color: white;
+        }
+        
+        .btn-success:hover {
+            background: #218838;
+        }
+        
+        .report-actions {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-top: 30px;
+            padding-top: 20px;
+            border-top: 1px solid #e1e5e9;
+        }
+        
+        .status-indicator {
+            padding: 8px 16px;
+            border-radius: 20px;
+            font-size: 12px;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+        
+        .status-draft {
+            background: #fff3cd;
+            color: #856404;
+        }
+        
+        .status-finalized {
+            background: #d4edda;
+            color: #155724;
+        }
+        
+        .loading {
+            display: none;
+            text-align: center;
+            padding: 20px;
+        }
+        
+        .spinner {
+            border: 4px solid #f3f3f3;
+            border-top: 4px solid #667eea;
+            border-radius: 50%;
+            width: 40px;
+            height: 40px;
+            animation: spin 1s linear infinite;
+            margin: 0 auto 10px;
+        }
+        
+        @keyframes spin {
+            0% { transform: rotate(0deg); }
+            100% { transform: rotate(360deg); }
+        }
+        
+        .alert {
+            padding: 12px 16px;
+            border-radius: 8px;
+            margin-bottom: 20px;
+            display: none;
+        }
+        
+        .alert-success {
+            background: #d4edda;
+            color: #155724;
+            border: 1px solid #c3e6cb;
+        }
+        
+        .alert-error {
+            background: #f8d7da;
+            color: #721c24;
+            border: 1px solid #f5c6cb;
+        }
+    </style>
+</head>
+<body>
+    <div class="report-container">
+        <div class="report-header">
+            <h1><i class="fas fa-file-medical"></i> Radiology Report</h1>
+            <div class="study-info">
+                <div class="info-item">
+                    <div class="info-label">Patient Name</div>
+                    <div class="info-value" id="patient-name">{{ study.patient_name|default:"Loading..." }}</div>
+                </div>
+                <div class="info-item">
+                    <div class="info-label">Patient ID</div>
+                    <div class="info-value" id="patient-id">{{ study.patient_id|default:"Loading..." }}</div>
+                </div>
+                <div class="info-item">
+                    <div class="info-label">Study Date</div>
+                    <div class="info-value" id="study-date">{{ study.study_date|default:"Loading..." }}</div>
+                </div>
+                <div class="info-item">
+                    <div class="info-label">Modality</div>
+                    <div class="info-value" id="modality">{{ study.modality|default:"Loading..." }}</div>
+                </div>
+                <div class="info-item">
+                    <div class="info-label">Accession Number</div>
+                    <div class="info-value" id="accession-number">{{ study.accession_number|default:"Loading..." }}</div>
+                </div>
+                <div class="info-item">
+                    <div class="info-label">Facility</div>
+                    <div class="info-value" id="facility">{{ study.facility.name|default:"Loading..." }}</div>
+                </div>
+            </div>
+        </div>
+        
+        <div class="report-form">
+            <div id="alert" class="alert"></div>
+            
+            <div class="form-section">
+                <h3><i class="fas fa-stethoscope"></i> Clinical Information</h3>
+                <div class="form-group">
+                    <label for="clinical-info">Clinical Information</label>
+                    <textarea id="clinical-info" class="form-control" placeholder="Enter clinical information..." readonly></textarea>
+                </div>
+            </div>
+            
+            <div class="form-section">
+                <h3><i class="fas fa-search"></i> Findings</h3>
+                <div class="form-group">
+                    <label for="findings">Findings</label>
+                    <textarea id="findings" class="form-control" placeholder="Describe the findings in detail..."></textarea>
+                </div>
+            </div>
+            
+            <div class="form-section">
+                <h3><i class="fas fa-lightbulb"></i> Impression</h3>
+                <div class="form-group">
+                    <label for="impression">Impression</label>
+                    <textarea id="impression" class="form-control" placeholder="Provide your impression and interpretation..."></textarea>
+                </div>
+            </div>
+            
+            <div class="form-section">
+                <h3><i class="fas fa-clipboard-list"></i> Recommendations</h3>
+                <div class="form-group">
+                    <label for="recommendations">Recommendations</label>
+                    <textarea id="recommendations" class="form-control" placeholder="Provide recommendations for follow-up or additional studies..."></textarea>
+                </div>
+            </div>
+            
+            <div class="report-actions">
+                <div>
+                    <button class="btn btn-secondary" onclick="window.location.href='/worklist/'">
+                        <i class="fas fa-arrow-left"></i> Back to Worklist
+                    </button>
+                    <button class="btn btn-primary" onclick="viewImages()">
+                        <i class="fas fa-eye"></i> View Images
+                    </button>
+                </div>
+                <div>
+                    <span id="status-indicator" class="status-indicator status-draft">Draft</span>
+                    <button class="btn btn-primary" onclick="saveReport(false)">
+                        <i class="fas fa-save"></i> Save Draft
+                    </button>
+                    <button class="btn btn-success" onclick="saveReport(true)">
+                        <i class="fas fa-check"></i> Finalize Report
+                    </button>
+                </div>
+            </div>
+        </div>
+        
+        <div id="loading" class="loading">
+            <div class="spinner"></div>
+            <p>Saving report...</p>
+        </div>
+    </div>
+    
+    <script>
+        let studyId = {{ study.id|default:"null" }};
+        let currentReport = null;
+        
+        // Load existing report data
+        window.addEventListener('load', function() {
+            if (studyId) {
+                loadReport();
+            }
+        });
+        
+        function loadReport() {
+            fetch(`/worklist/study/${studyId}/report/`)
+                .then(response => response.json())
+                .then(data => {
+                    if (data.findings) {
+                        document.getElementById('findings').value = data.findings;
+                        document.getElementById('impression').value = data.impression;
+                        document.getElementById('recommendations').value = data.recommendations;
+                        
+                        const statusIndicator = document.getElementById('status-indicator');
+                        if (data.status === 'finalized') {
+                            statusIndicator.textContent = 'Finalized';
+                            statusIndicator.className = 'status-indicator status-finalized';
+                        }
+                        
+                        currentReport = data;
+                    }
+                })
+                .catch(error => {
+                    console.error('Error loading report:', error);
+                    showAlert('Error loading existing report', 'error');
+                });
+        }
+        
+        function saveReport(finalize) {
+            const findings = document.getElementById('findings').value;
+            const impression = document.getElementById('impression').value;
+            const recommendations = document.getElementById('recommendations').value;
+            
+            if (!findings.trim() && !impression.trim()) {
+                showAlert('Please enter findings or impression before saving', 'error');
+                return;
+            }
+            
+            document.getElementById('loading').style.display = 'block';
+            
+            fetch(`/worklist/study/${studyId}/report/`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-CSRFToken': getCookie('csrftoken')
+                },
+                body: JSON.stringify({
+                    findings: findings,
+                    impression: impression,
+                    recommendations: recommendations,
+                    finalize: finalize
+                })
+            })
+            .then(response => response.json())
+            .then(data => {
+                document.getElementById('loading').style.display = 'none';
+                
+                if (data.success) {
+                    const statusIndicator = document.getElementById('status-indicator');
+                    if (finalize) {
+                        statusIndicator.textContent = 'Finalized';
+                        statusIndicator.className = 'status-indicator status-finalized';
+                        showAlert('Report finalized successfully!', 'success');
+                    } else {
+                        showAlert('Draft saved successfully!', 'success');
+                    }
+                } else {
+                    showAlert(data.error || 'Error saving report', 'error');
+                }
+            })
+            .catch(error => {
+                document.getElementById('loading').style.display = 'none';
+                console.error('Error saving report:', error);
+                showAlert('Error saving report', 'error');
+            });
+        }
+        
+        function viewImages() {
+            if (studyId) {
+                window.open(`/viewer/study/${studyId}/`, '_blank');
+            }
+        }
+        
+        function showAlert(message, type) {
+            const alert = document.getElementById('alert');
+            alert.textContent = message;
+            alert.className = `alert alert-${type}`;
+            alert.style.display = 'block';
+            
+            setTimeout(() => {
+                alert.style.display = 'none';
+            }, 5000);
+        }
+        
+        function getCookie(name) {
+            let cookieValue = null;
+            if (document.cookie && document.cookie !== '') {
+                const cookies = document.cookie.split(';');
+                for (let i = 0; i < cookies.length; i++) {
+                    const cookie = cookies[i].trim();
+                    if (cookie.substring(0, name.length + 1) === (name + '=')) {
+                        cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
+                        break;
+                    }
+                }
+            }
+            return cookieValue;
+        }
+    </script>
+</body>
+</html>

--- a/templates/worklist/worklist.html
+++ b/templates/worklist/worklist.html
@@ -314,7 +314,24 @@
         }
         
         function viewStudy(entryId) {
-            window.location.href = `/worklist/entry/${entryId}/view/`;
+            // Get the study ID from the entry and redirect to viewer
+            fetch(`/worklist/entry/${entryId}/view/`)
+                .then(response => {
+                    if (response.redirected) {
+                        window.location.href = response.url;
+                    } else {
+                        return response.json();
+                    }
+                })
+                .then(data => {
+                    if (data && data.error) {
+                        alert(data.error);
+                    }
+                })
+                .catch(error => {
+                    console.error('Error viewing study:', error);
+                    alert('Error opening study viewer');
+                });
         }
         
         function addClinicalInfo(entryId) {


### PR DESCRIPTION
Fix worklist 'View' and 'Report' button functionality and standalone DICOM viewer file/folder upload by correcting API endpoints and adding a report template.

The 'View' button in the worklist was redirecting to an incorrect URL, and the 'Report' button had no associated page. Additionally, the standalone DICOM viewer's file and folder upload features were failing due to incorrect API endpoint prefixes. This PR addresses these issues by updating the redirection logic, creating a dedicated report template, and correcting all `/api/` calls to `/viewer/api/` in the DICOM viewer JavaScript.

---
<a href="https://cursor.com/background-agent?bcId=bc-ecaef32c-093d-484c-9b74-559f30a762f8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ecaef32c-093d-484c-9b74-559f30a762f8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>