### PR TITLE
Fix dicom viewer and report navigation

### DIFF
--- a/static/js/dicom_viewer.js
+++ b/static/js/dicom_viewer.js
@@ -324,7 +324,7 @@ class DicomViewer {
         progressText.textContent = `Uploading ${validFiles.length} files...`;
         
         try {
-            const response = await fetch('/api/upload/', {
+            const response = await fetch('/viewer/api/upload/', {
                 method: 'POST',
                 body: formData,
                 headers: {
@@ -465,7 +465,7 @@ class DicomViewer {
         progressText.textContent = `Uploading ${dicomFiles.length} DICOM files...`;
         
         try {
-            const response = await fetch('/api/upload-folder/', {
+            const response = await fetch('/viewer/api/upload-folder/', {
                 method: 'POST',
                 body: formData,
                 headers: {
@@ -554,7 +554,7 @@ class DicomViewer {
     
     async loadBackendStudies() {
         try {
-            const response = await fetch('/api/studies/');
+            const response = await fetch('/viewer/api/studies/');
             const studies = await response.json();
             
             const select = document.getElementById('backend-studies');
@@ -580,7 +580,7 @@ class DicomViewer {
     
     async loadStudy(studyId) {
         try {
-            const response = await fetch(`/api/studies/${studyId}/images/`);
+            const response = await fetch(`/viewer/api/studies/${studyId}/images/`);
             
             if (!response.ok) {
                 throw new Error(`HTTP ${response.status}: ${response.statusText}`);
@@ -623,7 +623,7 @@ class DicomViewer {
                 inverted: this.inverted
             });
             
-            const response = await fetch(`/api/images/${imageData.id}/data/?${params}`);
+            const response = await fetch(`/viewer/api/images/${imageData.id}/data/?${params}`);
             
             if (!response.ok) {
                 throw new Error(`HTTP ${response.status}: ${response.statusText}`);
@@ -1319,7 +1319,7 @@ class DicomViewer {
         };
         
         try {
-            const response = await fetch('/api/measurements/save/', {
+            const response = await fetch('/viewer/api/measurements/save/', {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
@@ -1347,7 +1347,7 @@ class DicomViewer {
         };
         
         try {
-            const response = await fetch('/api/annotations/save/', {
+            const response = await fetch('/viewer/api/annotations/save/', {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
@@ -1369,7 +1369,7 @@ class DicomViewer {
         if (!this.currentImage) return;
         
         try {
-            const response = await fetch(`/api/images/${this.currentImage.id}/measurements/`);
+            const response = await fetch(`/viewer/api/images/${this.currentImage.id}/measurements/`);
             this.measurements = await response.json();
             this.updateMeasurementsList();
         } catch (error) {
@@ -1381,7 +1381,7 @@ class DicomViewer {
         if (!this.currentImage) return;
         
         try {
-            const response = await fetch(`/api/images/${this.currentImage.id}/annotations/`);
+            const response = await fetch(`/viewer/api/images/${this.currentImage.id}/annotations/`);
             this.annotations = await response.json();
         } catch (error) {
             console.error('Error loading annotations:', error);
@@ -1449,7 +1449,7 @@ class DicomViewer {
         if (!this.currentImage) return;
         
         try {
-            const response = await fetch(`/api/images/${this.currentImage.id}/clear-measurements/`, {
+            const response = await fetch(`/viewer/api/images/${this.currentImage.id}/clear-measurements/`, {
                 method: 'DELETE',
                 headers: {
                     'X-CSRFToken': this.getCSRFToken()
@@ -1477,7 +1477,7 @@ class DicomViewer {
             y1: ellipseData.end.y
         };
         try {
-            const response = await fetch('/api/measurements/hu/', {
+            const response = await fetch('/viewer/api/measurements/hu/', {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
@@ -1673,7 +1673,7 @@ class DicomViewer {
         const resultsDiv = document.getElementById('ai-results');
         resultsDiv.innerHTML = '<div class="loading">Performing AI analysis...</div>';
         
-        fetch(`/api/images/${this.currentImage.id}/ai-analysis/`, {
+        fetch(`/viewer/api/images/${this.currentImage.id}/ai-analysis/`, {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
@@ -2132,7 +2132,7 @@ class DicomViewer {
             unit: measurement.unit || this.measurementUnit
         };
         
-        fetch('/api/measurements/save/', {
+        fetch('/viewer/api/measurements/save/', {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
@@ -2167,7 +2167,7 @@ class DicomViewer {
             unit: 'HU'
         };
         
-        fetch('/api/measurements/save/', {
+        fetch('/viewer/api/measurements/save/', {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
@@ -2211,7 +2211,7 @@ class DicomViewer {
             color: color
         };
         
-        fetch('/api/annotations/save/', {
+        fetch('/viewer/api/annotations/save/', {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
@@ -2285,7 +2285,7 @@ class DicomViewer {
     async loadStudyImages(studyId) {
         console.log('Loading study images for study:', studyId);
         try {
-            const response = await fetch(`/api/studies/${studyId}/images/`);
+            const response = await fetch(`/viewer/api/studies/${studyId}/images/`);
             
             if (!response.ok) {
                 let errorMessage;

--- a/templates/worklist/report_form.html
+++ b/templates/worklist/report_form.html
@@ -1,0 +1,150 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Noctis - Write Report</title>
+    {% load static %}
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
+    <link rel="stylesheet" href="{% static 'css/worklist.css' %}">
+    <style>
+        body {
+            font-family: Arial, Helvetica, sans-serif;
+            background: #f4f6f9;
+            margin: 0;
+            padding: 0;
+        }
+        .report-container {
+            max-width: 900px;
+            margin: 30px auto;
+            padding: 20px;
+            background: #fff;
+            border-radius: 6px;
+            box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+        }
+        .report-container h2 {
+            margin-top: 0;
+        }
+        textarea {
+            width: 100%;
+            resize: vertical;
+            min-height: 120px;
+            padding: 10px;
+            border: 1px solid #ccc;
+            border-radius: 4px;
+            font-family: monospace;
+        }
+        .btn {
+            border: none;
+            padding: 10px 20px;
+            margin-right: 10px;
+            border-radius: 4px;
+            cursor: pointer;
+            font-weight: 600;
+        }
+        .btn-primary {
+            background: #28a745;
+            color: #fff;
+        }
+        .btn-secondary {
+            background: #007bff;
+            color: #fff;
+        }
+        .btn-cancel {
+            background: #6c757d;
+            color: #fff;
+        }
+        .status-indicator {
+            padding: 4px 10px;
+            background: #ffc107;
+            border-radius: 20px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            color: #212529;
+        }
+    </style>
+</head>
+<body>
+    <div class="report-container">
+        <h2><i class="fas fa-file-alt"></i> Radiology Report - {{ study.patient_name }}</h2>
+        <p>Study Date: {{ study.study_date }} | Modality: {{ study.modality }}</p>
+        <p id="report-status" class="status-indicator" style="display:none;"></p>
+
+        <label><strong>Findings</strong></label>
+        <textarea id="findings"></textarea>
+
+        <label><strong>Impression</strong></label>
+        <textarea id="impression"></textarea>
+
+        <label><strong>Recommendations</strong></label>
+        <textarea id="recommendations"></textarea>
+
+        <div style="margin-top:20px;">
+            <button class="btn btn-secondary" onclick="saveReport(false)"><i class="fas fa-save"></i> Save Draft</button>
+            <button class="btn btn-primary" onclick="saveReport(true)"><i class="fas fa-check"></i> Finalize</button>
+            <button class="btn btn-cancel" onclick="window.history.back()"><i class="fas fa-times"></i> Cancel</button>
+        </div>
+    </div>
+
+    <script>
+        const csrftoken = (function() {
+            const value = `; ${document.cookie}`;
+            const parts = value.split(`; csrftoken=`);
+            if (parts.length === 2) return parts.pop().split(';').shift();
+        })();
+
+        // Build AJAX url to fetch existing report data
+        const ajaxUrl = window.location.pathname + '?ajax=1';
+
+        fetch(ajaxUrl, {
+            headers: {
+                'X-Requested-With': 'XMLHttpRequest'
+            }
+        })
+        .then(resp => resp.ok ? resp.json() : {})
+        .then(data => {
+            if (data && Object.keys(data).length) {
+                document.getElementById('findings').value = data.findings || '';
+                document.getElementById('impression').value = data.impression || '';
+                document.getElementById('recommendations').value = data.recommendations || '';
+                document.getElementById('report-status').style.display = 'inline-block';
+                document.getElementById('report-status').textContent = 'Status: ' + (data.status || 'draft');
+            }
+        })
+        .catch(err => console.error('Failed to load report', err));
+
+        function saveReport(finalize) {
+            const payload = {
+                findings: document.getElementById('findings').value,
+                impression: document.getElementById('impression').value,
+                recommendations: document.getElementById('recommendations').value,
+                finalize: finalize
+            };
+
+            fetch(window.location.pathname, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-CSRFToken': csrftoken
+                },
+                body: JSON.stringify(payload)
+            })
+            .then(resp => resp.json())
+            .then(data => {
+                if (data.success) {
+                    alert(finalize ? 'Report finalized!' : 'Draft saved!');
+                    if (finalize) {
+                        window.location.href = '/worklist/';
+                    }
+                } else {
+                    alert('Failed to save report');
+                }
+            })
+            .catch(err => {
+                console.error('Save error', err);
+                alert('An error occurred while saving');
+            });
+        }
+    </script>
+</body>
+</html>


### PR DESCRIPTION
Fixes worklist "View" and "Report" button navigation and resolves DICOM viewer upload errors by correcting API endpoints.

The "View" button's redirect used an incorrect named URL pattern. The "Report" button previously only returned JSON, but now renders a dedicated report editing page. The standalone DICOM viewer's JavaScript was making API calls to `/api/` instead of the correct `/viewer/api/` paths, leading to server errors during file/folder uploads and other operations.

---
<a href="https://cursor.com/background-agent?bcId=bc-25a2f85d-f780-49da-8b09-1e4415ad7f35">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-25a2f85d-f780-49da-8b09-1e4415ad7f35">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>