### PR TITLE
Refine api middleware functionality

### DIFF
--- a/noctisview/middleware.py
+++ b/noctisview/middleware.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import time
 from django.http import JsonResponse
 from django.middleware.csrf import CsrfViewMiddleware
 from django.utils.deprecation import MiddlewareMixin
@@ -7,6 +8,8 @@ from django.conf import settings
 from django.core.exceptions import ValidationError, PermissionDenied
 from django.http import HttpResponseForbidden
 import traceback
+from django.middleware.csrf import get_token
+from django.views.decorators.csrf import csrf_exempt
 
 logger = logging.getLogger(__name__)
 
@@ -16,7 +19,7 @@ class APIErrorMiddleware(MiddlewareMixin):
     Middleware to handle API errors and ensure JSON responses for API endpoints.
     Provides detailed error logging and consistent error response format.
     """
-    
+
     def process_exception(self, request, exception):
         """Handle exceptions for API endpoints and return JSON responses."""
         # Check if this is an API request
@@ -61,6 +64,12 @@ class CSRFMiddleware(MiddlewareMixin):
     Provides better handling for file uploads and API requests.
     """
     
+    def __init__(self, get_response):
+        self.get_response = get_response
+        # Create the CSRF middleware instance with proper get_response
+        self.csrf_middleware = CsrfViewMiddleware(get_response)
+        super().__init__(get_response)
+    
     def process_view(self, request, callback, callback_args, callback_kwargs):
         # Skip CSRF check for specific API endpoints that handle file uploads
         if hasattr(callback, '__name__') and any(name in callback.__name__ for name in ['upload', 'save']):
@@ -70,9 +79,8 @@ class CSRFMiddleware(MiddlewareMixin):
         if hasattr(callback, 'csrf_exempt') and callback.csrf_exempt:
             return None
             
-        # Use Django's built-in CSRF middleware
-        csrf_middleware = CsrfViewMiddleware()
-        response = csrf_middleware.process_view(request, callback, callback_args, callback_kwargs)
+        # Use the properly initialized CSRF middleware
+        response = self.csrf_middleware.process_view(request, callback, callback_args, callback_kwargs)
         
         # If CSRF validation failed and this is an API request, return JSON error
         if response and (request.path.startswith('/api/') or request.path.startswith('/viewer/api/')):
@@ -183,7 +191,3 @@ class PerformanceMiddleware(MiddlewareMixin):
             elif request.path.startswith('/api/') or request.path.startswith('/viewer/api/'):
                 logger.debug(f"Request duration: {request.method} {request.path} took {duration:.3f}s")
         return response
-
-
-# Import time module for performance middleware
-import time


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Refactor `CSRFMiddleware` to correctly initialize and use Django's `CsrfViewMiddleware` and consolidate imports.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
This change ensures the CSRF middleware is properly configured and follows Django's middleware pattern, leading to more reliable CSRF token validation.

---
<a href="https://cursor.com/background-agent?bcId=bc-09d79a97-68d6-4103-859e-1706733ad7bb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-09d79a97-68d6-4103-859e-1706733ad7bb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>