### PR TITLE
Enhance admin and facility features with security and UI improvements

### DIFF
--- a/templates/admin/facility_form.html
+++ b/templates/admin/facility_form.html
@@ -314,6 +314,28 @@
                     <div class="helptext">Upload an image file (PNG, JPG, GIF) for the facility letterhead. Recommended size: 200x100px</div>
                 </div>
                 
+                <!-- NEW: Facility staff login credentials -->
+                <hr style="border:1px solid #333; margin:40px 0;">
+                <h3 style="color:#00ff00; margin-bottom:20px;">
+                    <i class="fas fa-user-lock"></i> Facility Login Credentials (optional)
+                </h3>
+
+                <div class="form-group">
+                    <label for="id_staff_username">Username</label>
+                    <input type="text" name="staff_username" id="id_staff_username" class="form-control" placeholder="facility_user">
+                    <div class="helptext">If provided, a user account will be created and linked to this facility.</div>
+                </div>
+
+                <div class="form-group">
+                    <label for="id_staff_password">Password</label>
+                    <input type="password" name="staff_password" id="id_staff_password" class="form-control" placeholder="••••••••">
+                </div>
+                
+                <div class="form-group">
+                    <label for="id_staff_email">Email (optional)</label>
+                    <input type="email" name="staff_email" id="id_staff_email" class="form-control" placeholder="user@facility.com">
+                </div>
+                
                 <div class="form-actions">
                     <button type="submit" class="btn btn-primary">
                         <i class="fas fa-save"></i> 

--- a/templates/admin/facility_list.html
+++ b/templates/admin/facility_list.html
@@ -257,6 +257,9 @@
                             <a href="{% url 'viewer:facility_edit' facility.pk %}" class="btn btn-edit">
                                 <i class="fas fa-edit"></i> Edit
                             </a>
+                            <a href="{% url 'viewer:facility_delete' facility.pk %}" class="btn btn-secondary" style="margin-left:6px;" onclick="return confirm('Are you sure you want to delete this facility? All associated data will be removed.');">
+                                <i class="fas fa-trash"></i> Delete
+                            </a>
                         </td>
                     </tr>
                     {% endfor %}

--- a/templates/dicom_viewer/viewer.html
+++ b/templates/dicom_viewer/viewer.html
@@ -57,10 +57,19 @@
                     <i class="fas fa-robot"></i>
                     <span>AI</span>
                 </button>
-                <button class="tool-btn" data-tool="3d" title="3D Reconstruction">
-                    <i class="fas fa-cube"></i>
-                    <span>3D</span>
-                </button>
+                <div class="dropdown">
+                    <button class="tool-btn dropdown-toggle" title="3D Reconstruction" onclick="const m=document.getElementById('dropdown-3d');m.style.display = (m.style.display==='block') ? 'none' : 'block';">
+                        <i class="fas fa-cube"></i>
+                        <span>3D</span>
+                        <i class="fas fa-chevron-down" style="margin-left:4px;"></i>
+                    </button>
+                    <div id="dropdown-3d" class="dropdown-menu" style="display:none;">
+                        <button class="dropdown-item" data-3d="mpr">Multi-planar (MPR)</button>
+                        <button class="dropdown-item" data-3d="bone">Bone window</button>
+                        <button class="dropdown-item" data-3d="angiogram">CT-Angiogram</button>
+                        <button class="dropdown-item" data-3d="virtual_surgery">Virtual surgery</button>
+                    </div>
+                </div>
             </div>
         </div>
 
@@ -302,7 +311,41 @@
             if (window.initialStudyId) {
                 loadClinicalInfo(window.initialStudyId);
             }
+
+            // 3D dropdown behaviour
+            document.addEventListener('click', function(evt){
+                const menu = document.getElementById('dropdown-3d');
+                if(!menu) return;
+                if(!evt.target.closest('.dropdown')){
+                    menu.style.display = 'none';
+                }
+            });
+
+            const dropdownMenu = document.getElementById('dropdown-3d');
+            if(dropdownMenu){
+                dropdownMenu.querySelectorAll('.dropdown-item').forEach(function(item){
+                    item.addEventListener('click', function(){
+                        const reconType = this.getAttribute('data-3d');
+                        dropdownMenu.style.display='none';
+                        if(window.currentSeriesId){
+                            perform3DReconstruction(window.currentSeriesId, reconType);
+                        } else {
+                            alert('Load a series first.');
+                        }
+                    });
+                });
+            }
         });
+
+        function perform3DReconstruction(seriesId, reconType){
+            fetch(`/viewer/api/series/${seriesId}/3d-reconstruction/?type=${reconType}`)
+                .then(r=>r.json())
+                .then(data=>{
+                    console.log('3D Reconstruction data', data);
+                    alert('3D reconstruction ('+reconType+') ready – integrate rendering logic here.');
+                })
+                .catch(err=>alert('Error performing 3D reconstruction: '+err));
+        }
     </script>
     <script src="{% static 'js/dicom_viewer.js' %}"></script>
 </body>

--- a/templates/worklist/facility_worklist.html
+++ b/templates/worklist/facility_worklist.html
@@ -117,6 +117,9 @@
                 <button class="btn btn-view" onclick="window.location.href='/worklist/'">
                     <i class="fas fa-arrow-left"></i> Back to Main Worklist
                 </button>
+                <button class="btn btn-secondary" onclick="window.location.href='{% url 'logout' %}'" style="margin-left:10px;">
+                    <i class="fas fa-sign-out-alt"></i> Logout
+                </button>
             </div>
         </div>
         

--- a/viewer/admin.py
+++ b/viewer/admin.py
@@ -4,7 +4,7 @@ from django.contrib.auth.admin import UserAdmin
 from django.contrib.auth.models import User
 from .models import (
     Facility, DicomStudy, DicomSeries, DicomImage, Measurement, 
-    Annotation, Report, WorklistEntry, AIAnalysis, Notification
+    Annotation, Report, WorklistEntry, AIAnalysis, Notification, FacilityStaff
 )
 
 # Register your models here.
@@ -108,3 +108,10 @@ class AnnotationAdmin(admin.ModelAdmin):
             'fields': ('created_by', 'created_at')
         }),
     )
+
+
+@admin.register(FacilityStaff)
+class FacilityStaffAdmin(admin.ModelAdmin):
+    list_display = ['user', 'facility', 'created_at']
+    search_fields = ['user__username', 'facility__name']
+    list_filter = ['facility']

--- a/viewer/models.py
+++ b/viewer/models.py
@@ -28,6 +28,27 @@ class Facility(models.Model):
     def __str__(self):
         return self.name
 
+# -- NEW CODE: FacilityStaff model to map a login user to their Facility --
+class FacilityStaff(models.Model):
+    """Link a Django auth ``User`` to a ``Facility`` so that we can easily check
+    which facility a logged-in user belongs to.  The reverse relation
+    ``user.facility_staff`` is relied upon in multiple views (viewer & worklist) –
+    adding this model makes those look-ups work out of the box.
+    Only non-admin users that upload or review their own studies will be added
+    to this table.
+    """
+
+    user = models.OneToOneField(User, on_delete=models.CASCADE, related_name="facility_staff")
+    facility = models.ForeignKey(Facility, on_delete=models.CASCADE, related_name="staff_members")
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        verbose_name_plural = "Facility staff"
+        unique_together = ("user", "facility")
+
+    def __str__(self):
+        return f"{self.user.username} – {self.facility.name}"
+
 
 class DicomStudy(models.Model):
     """Model to represent a DICOM study"""

--- a/viewer/urls.py
+++ b/viewer/urls.py
@@ -12,6 +12,7 @@ urlpatterns = [
     path('admin/facilities/', views.FacilityListView.as_view(), name='facility_list'),
     path('admin/facilities/new/', views.FacilityCreateView.as_view(), name='facility_create'),
     path('admin/facilities/<int:pk>/edit/', views.FacilityUpdateView.as_view(), name='facility_edit'),
+    path('admin/facilities/<int:pk>/delete/', views.facility_delete, name='facility_delete'),
     path('admin/radiologists/', views.RadiologistListView.as_view(), name='radiologist_list'),
     path('admin/radiologists/new/', views.create_radiologist, name='radiologist_create'),
     


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Adds facility deletion for admins, enables facility user creation during facility setup, and refines the DICOM viewer's 3D reconstruction UI.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
This PR addresses several key user requests: providing administrators with full control over facility data including deletion (and associated user accounts), streamlining the process of creating dedicated login accounts for facilities to manage their own studies, and improving the professional appearance and functionality of the DICOM viewer's 3D tools.

---
<a href="https://cursor.com/background-agent?bcId=bc-d170ecc9-05ce-43d6-8c4e-1df80afbfbde">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d170ecc9-05ce-43d6-8c4e-1df80afbfbde">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>