### PR TITLE
Fix dicom viewer display and worklist status

### DIFF
--- a/templates/dicom_viewer/viewer.html
+++ b/templates/dicom_viewer/viewer.html
@@ -123,9 +123,7 @@
                         <i class="fas fa-sign-out-alt"></i>
                         Logout
                     </button>
-                    <select id="backend-studies" class="form-select">
-                        <option value="">Select DICOM from System</option>
-                    </select>
+                    <!-- Backend study dropdown removed as worklist navigation supersedes it -->
                     <div class="patient-info" id="patient-info">
                         Patient: - | Study Date: - | Modality: -
                     </div>

--- a/templates/worklist/worklist.html
+++ b/templates/worklist/worklist.html
@@ -126,16 +126,16 @@
                                         <i class="fas fa-file-medical"></i> Clinical
                                     </button>
                                     {% if is_radiologist or is_admin %}
-                                    {% if entry.study %}
-                                    <button class="btn btn-report" onclick="writeReport({{ entry.study.id }})">
-                                        <i class="fas fa-file-alt"></i> Report
-                                    </button>
-                                    {% if entry.study.reports.exists %}
-                                    <button class="btn btn-print" onclick="printReport({{ entry.study.reports.first.id }})">
-                                        <i class="fas fa-print"></i> Print
-                                    </button>
+                                        {% if entry.study %}
+                                            <button class="btn btn-report" onclick="writeReport({{ entry.study.id }})">
+                                                <i class="fas fa-file-alt"></i> Report
+                                            </button>
+                                        {% endif %}
                                     {% endif %}
-                                    {% endif %}
+                                    {% if entry.study and entry.study.reports.exists %}
+                                        <button class="btn btn-print" onclick="printReport({{ entry.study.reports.first.id }})">
+                                            <i class="fas fa-print"></i> Print
+                                        </button>
                                     {% endif %}
                                 </div>
                             </td>


### PR DESCRIPTION
Refactor DICOM image loading and streamline viewer UI to improve reliability and usability.

This PR addresses persistent DICOM image loading failures by implementing a more robust file path resolution strategy in `DicomImage.load_dicom_data`. It also streamlines the DICOM viewer UI by removing the redundant "Select DICOM from System" dropdown, as worklist navigation is now the primary entry point. Additionally, the "Print" report action is made universally accessible for completed reports, enhancing user experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-68b55efe-a926-48e8-a7ad-cbe7d3bf3f54">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-68b55efe-a926-48e8-a7ad-cbe7d3bf3f54">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>