### PR TITLE
Add admin delete button to worklist

### DIFF
--- a/static/css/worklist.css
+++ b/static/css/worklist.css
@@ -194,6 +194,15 @@ body {
     color: #fff;
 }
 
+.btn-delete {
+    background: #dc3545;
+    color: #fff;
+}
+
+.btn-delete:hover {
+    background: #c82333;
+}
+
 .status-badge {
     padding: 4px 12px;
     border-radius: 12px;

--- a/templates/worklist/worklist.html
+++ b/templates/worklist/worklist.html
@@ -137,6 +137,11 @@
                                         <i class="fas fa-print"></i> Print
                                     </button>
                                     {% endif %}
+                                    {% if is_admin %}
+                                    <button class="btn btn-delete" onclick="deleteEntry({{ entry.id }})">
+                                        <i class="fas fa-trash"></i> Delete
+                                    </button>
+                                    {% endif %}
                                 </div>
                             </td>
                         </tr>
@@ -429,6 +434,27 @@
         
         function printReport(reportId) {
             window.open(`/worklist/report/${reportId}/print/`, '_blank');
+        }
+        
+        function deleteEntry(entryId) {
+            if (confirm('Are you sure you want to delete this entry? This action cannot be undone.')) {
+                fetch(`/worklist/entry/${entryId}/delete/`, {
+                    method: 'POST',
+                    headers: {
+                        'X-CSRFToken': getCSRFToken()
+                    }
+                })
+                .then(response => response.json())
+                .then(data => {
+                    if (data.success) {
+                        alert('Entry deleted successfully!');
+                        location.reload(); // Reload to show updated worklist
+                    } else {
+                        alert('Error deleting entry: ' + data.error);
+                    }
+                })
+                .catch(error => console.error('Error deleting entry:', error));
+            }
         }
         
         function getCookie(name) {

--- a/worklist/urls.py
+++ b/worklist/urls.py
@@ -35,4 +35,5 @@ urlpatterns = [
     path('api/chat/', views.api_chat_messages, name='api_chat_messages'),
     path('api/chat/send/', views.api_chat_send, name='api_chat_send'),
     path('api/chat/clear/', views.api_chat_clear, name='api_chat_clear'),
+    path('entry/<int:entry_id>/delete/', views.delete_worklist_entry, name='delete_worklist_entry'),
 ]

--- a/worklist/views.py
+++ b/worklist/views.py
@@ -574,3 +574,17 @@ def create_system_upload_message(study, user):
         message=f'New study uploaded: {study.patient_name} - {study.study_description or study.modality}',
         related_study=study
     )
+
+
+@login_required
+@require_http_methods(['POST'])
+def delete_worklist_entry(request, entry_id):
+    """Delete a worklist entry (admin only)."""
+    entry = get_object_or_404(WorklistEntry, id=entry_id)
+
+    # Only administrators (superusers) can delete worklist entries
+    if not request.user.is_superuser:
+        return JsonResponse({'error': 'Permission denied'}, status=403)
+
+    entry.delete()
+    return JsonResponse({'success': True})


### PR DESCRIPTION
Add a delete button to worklist entries, visible and functional only for administrators.

---
<a href="https://cursor.com/background-agent?bcId=bc-af6d1f0a-c5a2-4895-be27-ed5b7ac44ea8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-af6d1f0a-c5a2-4895-be27-ed5b7ac44ea8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>