### PR TITLE
Fix dicom viewer display and functionality

### DIFF
--- a/viewer/views.py
+++ b/viewer/views.py
@@ -941,16 +941,16 @@ def get_study_images(request, study_id):
         for image in images:
             image_data = {
                 'id': image.id,
-                'instance_number': image.instance_number,
-                'series_number': image.series.series_number,
+                'instance_number': int(image.instance_number) if image.instance_number is not None else None,
+                'series_number': int(image.series.series_number) if image.series and image.series.series_number is not None else None,
                 'series_description': image.series.series_description,
-                'rows': image.rows,
-                'columns': image.columns,
-                'pixel_spacing_x': image.pixel_spacing_x,
-                'pixel_spacing_y': image.pixel_spacing_y,
-                'slice_thickness': image.slice_thickness,
-                'window_width': image.window_width,
-                'window_center': image.window_center,
+                'rows': int(image.rows) if image.rows is not None else None,
+                'columns': int(image.columns) if image.columns is not None else None,
+                'pixel_spacing_x': float(image.pixel_spacing_x) if image.pixel_spacing_x is not None else None,
+                'pixel_spacing_y': float(image.pixel_spacing_y) if image.pixel_spacing_y is not None else None,
+                'slice_thickness': float(image.slice_thickness) if image.slice_thickness is not None else None,
+                'window_width': float(image.window_width) if image.window_width is not None else None,
+                'window_center': float(image.window_center) if image.window_center is not None else None,
             }
             images_data.append(image_data)
         


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Explicitly convert numeric fields to native types in `get_study_images` to fix DICOM viewer display issues.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
This change prevents JSON serialization errors that were blocking the DICOM viewer from loading images, patient details, and clinical history due to non-native numeric types in the API response.

---
<a href="https://cursor.com/background-agent?bcId=bc-e8e812b8-09ef-4639-a813-12c073df302b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e8e812b8-09ef-4639-a813-12c073df302b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>