### PR TITLE
Add print button to worklist actions

### DIFF
--- a/templates/worklist/worklist.html
+++ b/templates/worklist/worklist.html
@@ -133,9 +133,13 @@
                                     {% endif %}
                                     {% endif %}
                                     {% if entry.study.reports.exists %}
-                                    <button class="btn btn-print" onclick="printReport({{ entry.study.reports.first.id }})">
-                                        <i class="fas fa-print"></i> Print
-                                    </button>
+                                        {% with report=entry.study.reports.first %}
+                                            {% if report.status == 'finalized' or report.status == 'printed' %}
+                                            <button class="btn btn-print" onclick="printReport({{ report.id }})">
+                                                <i class="fas fa-print"></i> Print
+                                            </button>
+                                            {% endif %}
+                                        {% endwith %}
                                     {% endif %}
                                     {% if is_admin %}
                                     <button class="btn btn-delete" onclick="deleteEntry({{ entry.id }}, '{{ entry.patient_name }}', '{{ entry.accession_number }}')">

--- a/worklist/views.py
+++ b/worklist/views.py
@@ -247,12 +247,8 @@ def print_report(request, report_id):
     report = get_object_or_404(Report, id=report_id)
     study = report.study
     
-    # Check permissions
-    if not (request.user.is_superuser or 
-            request.user.groups.filter(name='Radiologists').exists() or
-            (hasattr(request.user, 'facility_staff') and 
-             request.user.facility_staff.facility == study.facility)):
-        return HttpResponse('Permission denied', status=403)
+    # Allow all authenticated users to print reports
+    # No additional permission checks needed since @login_required already ensures authentication
     
     # Create PDF
     buffer = io.BytesIO()


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Enable print button for all authenticated users and ensure it only appears for finalized/printed reports.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The print button was not visible to all users due to restrictive permissions in the `print_report` view, which only allowed superusers, radiologists, or specific facility staff. This PR removes these restrictions, allowing any authenticated user to print. Additionally, the template logic in `worklist.html` has been updated to only display the print button for reports with 'finalized' or 'printed' status, aligning its behavior with `facility_worklist.html`.

---
<a href="https://cursor.com/background-agent?bcId=bc-cd6495d1-26a7-4dd6-8b1e-8c2c1dc7d354">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cd6495d1-26a7-4dd6-8b1e-8c2c1dc7d354">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>