### PR TITLE
Add print button to worklist actions

### DIFF
--- a/templates/worklist/facility_worklist.html
+++ b/templates/worklist/facility_worklist.html
@@ -137,6 +137,9 @@
                 <button class="btn btn-view" onclick="window.location.href='/worklist/'">
                     <i class="fas fa-arrow-left"></i> Back to Main Worklist
                 </button>
+                <button class="btn btn-print" onclick="printWorklist()">
+                    <i class="fas fa-print"></i> Print Worklist
+                </button>
                 <button class="btn btn-logout" onclick="window.location.href='/accounts/logout/'">
                     <i class="fas fa-sign-out-alt"></i> Logout
                 </button>
@@ -250,6 +253,24 @@
         function printReport(reportId) {
             window.open(`/worklist/report/${reportId}/print/`, '_blank');
         }
+
+        function printWorklist() {
+            // Store original title
+            const originalTitle = document.title;
+            
+            // Set print-friendly title
+            document.title = 'Facility Worklist - {{ facility.name }} - ' + new Date().toLocaleDateString();
+            
+            // Add print class to body
+            document.body.classList.add('printing');
+            
+            // Print
+            window.print();
+            
+            // Remove print class and restore title
+            document.body.classList.remove('printing');
+            document.title = originalTitle;
+        }
         
         // Highlight rows on hover
         document.querySelectorAll('.patient-row').forEach(row => {
@@ -264,5 +285,89 @@
             });
         });
     </script>
+    
+    <style>
+        @media print {
+            /* Hide non-essential elements when printing */
+            .header-actions,
+            .btn-view,
+            .btn-print {
+                display: none !important;
+            }
+            
+            /* Reset colors for print */
+            body {
+                background: white;
+                color: black;
+            }
+            
+            .worklist-container {
+                padding: 0;
+                height: auto;
+            }
+            
+            .facility-header {
+                background: white;
+                color: black;
+                border-bottom: 2px solid black;
+                margin-bottom: 10px;
+            }
+            
+            .facility-info {
+                color: black;
+            }
+            
+            .header {
+                background: white;
+                border-bottom: 1px solid black;
+                padding: 10px 0;
+            }
+            
+            .header h2 {
+                color: black;
+                font-size: 18px;
+            }
+            
+            /* Make table print-friendly */
+            .worklist-table {
+                border: 1px solid black;
+                overflow: visible;
+            }
+            
+            table {
+                width: 100%;
+                border-collapse: collapse;
+                font-size: 10pt;
+            }
+            
+            th, td {
+                border: 1px solid black;
+                padding: 5px;
+                background: white;
+                color: black;
+            }
+            
+            th {
+                background: #f0f0f0;
+                font-weight: bold;
+            }
+            
+            .status-badge,
+            .report-status {
+                background: none;
+                color: black;
+                padding: 2px 5px;
+                border: 1px solid black;
+            }
+            
+            /* Add print date/time */
+            .header::after {
+                content: "Printed: " attr(data-print-date);
+                display: block;
+                font-size: 12px;
+                margin-top: 5px;
+            }
+        }
+    </style>
 </body>
 </html>

--- a/templates/worklist/worklist.html
+++ b/templates/worklist/worklist.html
@@ -16,6 +16,9 @@
                 <button class="btn btn-view" onclick="window.location.href='/home/'">
                     <i class="fas fa-home"></i> Home
                 </button>
+                <button class="btn btn-print" onclick="printWorklist()">
+                    <i class="fas fa-print"></i> Print Worklist
+                </button>
                 {% if is_admin or is_radiologist %}
                 <div class="notification-area">
                     <button id="notification-bell" class="notification-bell" onclick="toggleNotifications()">
@@ -724,6 +727,116 @@
         checkNotifications();
         setInterval(checkNotifications, 30000);
         {% endif %}
+        
+        // Print worklist functionality
+        function printWorklist() {
+            // Store original title
+            const originalTitle = document.title;
+            
+            // Set print-friendly title
+            document.title = 'Noctis Worklist - ' + new Date().toLocaleDateString();
+            
+            // Add print class to body
+            document.body.classList.add('printing');
+            
+            // Print
+            window.print();
+            
+            // Remove print class and restore title
+            document.body.classList.remove('printing');
+            document.title = originalTitle;
+        }
     </script>
+    
+    <style>
+        @media print {
+            /* Hide non-essential elements when printing */
+            .header-actions,
+            .upload-section,
+            .filters,
+            .pagination,
+            .clinical-modal,
+            .notifications-panel,
+            .chat-panel,
+            .btn-view,
+            .btn-clinical,
+            .btn-report,
+            .btn-print,
+            .btn-delete {
+                display: none !important;
+            }
+            
+            /* Reset colors for print */
+            body {
+                background: white;
+                color: black;
+            }
+            
+            .worklist-container {
+                padding: 0;
+                height: auto;
+            }
+            
+            .header {
+                background: white;
+                border-bottom: 2px solid black;
+                padding: 10px 0;
+            }
+            
+            .header h1 {
+                color: black;
+                font-size: 20px;
+            }
+            
+            /* Make table print-friendly */
+            .worklist-table-container {
+                overflow: visible;
+                height: auto;
+                margin: 0;
+            }
+            
+            .worklist-table {
+                border: 1px solid black;
+            }
+            
+            table {
+                width: 100%;
+                border-collapse: collapse;
+                font-size: 10pt;
+            }
+            
+            th, td {
+                border: 1px solid black;
+                padding: 5px;
+                background: white;
+                color: black;
+            }
+            
+            th {
+                background: #f0f0f0;
+                font-weight: bold;
+            }
+            
+            .status-badge {
+                background: none;
+                color: black;
+                padding: 2px 5px;
+                border: 1px solid black;
+            }
+            
+            /* Add print date/time */
+            .header::after {
+                content: "Printed: " attr(data-print-date);
+                display: block;
+                font-size: 12px;
+                margin-top: 5px;
+            }
+        }
+        
+        /* Add print date dynamically */
+        body.printing .header::after {
+            content: "Printed: " attr(data-print-date);
+        }
+    </style>
 </body>
 </html>


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Add a "Print Worklist" button to allow users to print the worklist table itself, addressing the request for a universal print option beyond just reports.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The existing print functionality was limited to finalized radiology reports, meaning the print button was only visible when a report existed. This PR introduces a new "Print Worklist" button that enables users to print the current view of the worklist table, providing a general print capability for all worklist entries.

---
<a href="https://cursor.com/background-agent?bcId=bc-298e31bc-ba4a-42f8-a612-1a2bad4241cf">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-298e31bc-ba4a-42f8-a612-1a2bad4241cf">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>