### PR TITLE
Fix dicom pixel spacing error

### DIFF
--- a/viewer/views.py
+++ b/viewer/views.py
@@ -879,6 +879,18 @@ def upload_dicom_folder(request):
                             except:
                                 photometric_interpretation = 'MONOCHROME2'
                         
+                        # Parse pixel spacing
+                        pixel_spacing_x = None
+                        pixel_spacing_y = None
+                        if hasattr(dicom_data, 'PixelSpacing'):
+                            try:
+                                pixel_spacing = dicom_data.PixelSpacing
+                                if isinstance(pixel_spacing, (list, tuple)) and len(pixel_spacing) >= 2:
+                                    pixel_spacing_x = float(pixel_spacing[0])
+                                    pixel_spacing_y = float(pixel_spacing[1])
+                            except:
+                                pass
+                        
                         image, created = DicomImage.objects.get_or_create(
                             series=series,
                             sop_instance_uid=image_instance_uid,


### PR DESCRIPTION
Add pixel spacing parsing logic to fix 'pixel_spacing_x' not defined error during DICOM file upload.

---
<a href="https://cursor.com/background-agent?bcId=bc-6e96e771-75d9-47d9-a6d6-a1b375463eac">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6e96e771-75d9-47d9-a6d6-a1b375463eac">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>