### PR TITLE
Fix dicom viewer not displaying images

### DIFF
--- a/static/js/dicom_viewer.js
+++ b/static/js/dicom_viewer.js
@@ -703,7 +703,9 @@ class DicomViewer {
                         pixel_spacing_x: data.metadata.pixel_spacing_x,
                         pixel_spacing_y: data.metadata.pixel_spacing_y,
                         pixel_spacing: `${data.metadata.pixel_spacing_x},${data.metadata.pixel_spacing_y}`,
-                        slice_thickness: data.metadata.slice_thickness
+                        slice_thickness: data.metadata.slice_thickness,
+                        width: img.width,
+                        height: img.height
                     };
                     // Ensure canvas is properly sized before drawing
                     this.resizeCanvas();
@@ -2633,6 +2635,9 @@ Pixel Count: ${data.pixel_count}`;
         this.ctx.fillRect(0, 0, this.canvas.width, this.canvas.height);
         
         if (this.currentImage) {
+            // Determine the actual image element (handles both wrapped object and direct Image)
+            const imgElement = this.currentImage.image || this.currentImage;
+            
             // Save context state
             this.ctx.save();
             
@@ -2643,11 +2648,11 @@ Pixel Count: ${data.pixel_count}`;
             this.ctx.translate(this.panX, this.panY);
             
             // Calculate centered position
-            const x = (this.canvas.width - this.currentImage.width) / 2;
-            const y = (this.canvas.height - this.currentImage.height) / 2;
+            const x = (this.canvas.width - imgElement.width) / 2;
+            const y = (this.canvas.height - imgElement.height) / 2;
             
             // Draw the image
-            this.ctx.drawImage(this.currentImage, x, y);
+            this.ctx.drawImage(imgElement, x, y);
             
             // Restore context for UI elements
             this.ctx.restore();


### PR DESCRIPTION
Fix DICOM viewer not displaying images by correctly drawing the image element and storing its dimensions.

The previous implementation attempted to draw a wrapper object or lacked consistent image dimensions, causing JavaScript errors and preventing the image from rendering on the canvas. This change ensures the correct image element is drawn and its dimensions are available for proper centering.

---
<a href="https://cursor.com/background-agent?bcId=bc-253961f3-e7f4-47e6-93d1-7e2a1a12b65d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-253961f3-e7f4-47e6-93d1-7e2a1a12b65d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>