### PR TITLE
Fix dicom viewer not displaying images

### DIFF
--- a/static/js/dicom_viewer.js
+++ b/static/js/dicom_viewer.js
@@ -80,7 +80,35 @@ class DicomViewer {
         // Load initial study if provided
         if (this.initialStudyId) {
             console.log('Loading initial study:', this.initialStudyId);
-            await this.loadStudy(this.initialStudyId);
+            try {
+                await this.loadStudy(this.initialStudyId);
+            } catch (error) {
+                console.error('Failed to load initial study:', error);
+                this.showError('Failed to load study: ' + error.message);
+                
+                // Show detailed error message on canvas
+                this.ctx.fillStyle = '#000';
+                this.ctx.fillRect(0, 0, this.canvas.width, this.canvas.height);
+                this.ctx.fillStyle = '#ff0000';
+                this.ctx.font = '16px Arial';
+                this.ctx.textAlign = 'center';
+                this.ctx.textBaseline = 'middle';
+                this.ctx.fillText('Failed to load study', this.canvas.width / 2, this.canvas.height / 2 - 40);
+                this.ctx.fillText('Study ID: ' + this.initialStudyId, this.canvas.width / 2, this.canvas.height / 2 - 20);
+                this.ctx.fillText('Error: ' + error.message, this.canvas.width / 2, this.canvas.height / 2);
+                this.ctx.fillText('Check browser console for details', this.canvas.width / 2, this.canvas.height / 2 + 20);
+            }
+        } else {
+            console.log('No initial study ID provided');
+            // Show welcome message
+            this.ctx.fillStyle = '#000';
+            this.ctx.fillRect(0, 0, this.canvas.width, this.canvas.height);
+            this.ctx.fillStyle = '#fff';
+            this.ctx.font = '20px Arial';
+            this.ctx.textAlign = 'center';
+            this.ctx.textBaseline = 'middle';
+            this.ctx.fillText('No study selected', this.canvas.width / 2, this.canvas.height / 2 - 20);
+            this.ctx.fillText('Upload DICOM files or select from worklist', this.canvas.width / 2, this.canvas.height / 2 + 20);
         }
     }
     
@@ -601,23 +629,30 @@ class DicomViewer {
             this.ctx.textBaseline = 'middle';
             this.ctx.fillText('Loading study...', this.canvas.width / 2, this.canvas.height / 2);
             
+            console.log(`Fetching study data from: /viewer/api/studies/${studyId}/images/`);
             const response = await fetch(`/viewer/api/studies/${studyId}/images/`);
+            
+            console.log(`Response status: ${response.status} ${response.statusText}`);
             
             if (!response.ok) {
                 const errorText = await response.text();
+                console.error('Error response text:', errorText);
                 let errorMessage;
                 try {
                     const errorData = JSON.parse(errorText);
                     errorMessage = errorData.error || `HTTP ${response.status}: ${response.statusText}`;
                 } catch (e) {
                     errorMessage = `HTTP ${response.status}: ${response.statusText}`;
+                    console.error('Failed to parse error response:', e);
                 }
                 throw new Error(errorMessage);
             }
             
             const data = await response.json();
+            console.log('Received study data:', data);
             
             if (!data.images || data.images.length === 0) {
+                console.error('No images found in study data:', data);
                 throw new Error('No images found in this study');
             }
             
@@ -638,6 +673,7 @@ class DicomViewer {
             this.updateSliders();
             
             // Load the first image
+            console.log('Loading first image...');
             await this.loadCurrentImage();
             
             // Load clinical info if available
@@ -663,6 +699,9 @@ class DicomViewer {
             
             // Reset patient info on error
             this.updatePatientInfo();
+            
+            // Re-throw the error so it can be caught by the caller
+            throw error;
         }
     }
     
@@ -674,6 +713,7 @@ class DicomViewer {
         
         const imageData = this.currentImages[this.currentImageIndex];
         console.log(`Loading image ${this.currentImageIndex + 1}/${this.currentImages.length}, ID: ${imageData.id}`);
+        console.log('Image data:', imageData);
         
         try {
             const params = new URLSearchParams({
@@ -682,18 +722,26 @@ class DicomViewer {
                 inverted: this.inverted
             });
             
-            const response = await fetch(`/viewer/api/images/${imageData.id}/data/?${params}`);
+            const imageUrl = `/viewer/api/images/${imageData.id}/data/?${params}`;
+            console.log(`Fetching image data from: ${imageUrl}`);
+            
+            const response = await fetch(imageUrl);
+            console.log(`Image response status: ${response.status} ${response.statusText}`);
             
             if (!response.ok) {
+                const errorText = await response.text();
+                console.error('Image error response:', errorText);
                 throw new Error(`HTTP ${response.status}: ${response.statusText}`);
             }
             
             const data = await response.json();
+            console.log('Received image data response:', data);
             
             if (data.image_data) {
+                console.log('Creating image element...');
                 const img = new Image();
                 img.onload = () => {
-                    console.log('Image loaded successfully');
+                    console.log('Image loaded successfully, dimensions:', img.width, 'x', img.height);
                     this.currentImage = {
                         image: img,
                         metadata: data.metadata,
@@ -714,12 +762,18 @@ class DicomViewer {
                 };
                 img.onerror = (error) => {
                     console.error('Failed to load image data:', error);
-                    console.error('Image source:', img.src);
+                    console.error('Image source length:', img.src.length);
+                    console.error('Image source preview:', img.src.substring(0, 100));
                     this.showError('Failed to load image. Please try refreshing or selecting another image.');
                 };
+                console.log('Setting image source...');
                 img.src = data.image_data;
+            } else if (data.error) {
+                console.error('Server returned error:', data.error);
+                throw new Error(data.error);
             } else {
-                throw new Error(data.error || 'No image data received');
+                console.error('No image data in response:', data);
+                throw new Error('No image data received');
             }
             
         } catch (error) {

--- a/staticfiles/css/dicom_viewer.css
+++ b/staticfiles/css/dicom_viewer.css
@@ -11,12 +11,16 @@ body {
     background: #1a1a1a;
     color: #e0e0e0;
     overflow: hidden;
+    height: 100vh;
+    width: 100vw;
 }
 
 /* Layout */
 .dicom-viewer {
     display: flex;
     height: 100vh;
+    width: 100vw;
+    position: relative;
 }
 
 .toolbar {
@@ -27,18 +31,123 @@ body {
     flex-direction: column;
     align-items: center;
     box-shadow: 2px 0 10px rgba(0, 0, 0, 0.5);
+    position: relative;
+    z-index: 100;
 }
 
 .main-content {
     flex: 1;
     display: flex;
     flex-direction: column;
+    min-height: 0; /* Fix flex overflow */
 }
 
 .top-bar {
     background: #252525;
     padding: 15px;
     box-shadow: 0 2px 10px rgba(0, 0, 0, 0.3);
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    flex-wrap: wrap;
+    min-height: auto;
+    max-height: 120px; /* Prevent excessive height */
+}
+
+.top-controls {
+    display: flex;
+    gap: 10px;
+    align-items: center;
+    flex-wrap: wrap;
+}
+
+.study-info {
+    flex: 1;
+    margin-left: 20px;
+    min-width: 300px;
+}
+
+.patient-info {
+    font-weight: bold;
+    font-size: 14px;
+    margin-bottom: 5px;
+    color: #fff;
+}
+
+/* Responsive Design */
+@media (max-width: 1200px) {
+    .right-panel {
+        width: 250px;
+    }
+    
+    .toolbar {
+        width: 70px;
+    }
+    
+    .tool-btn {
+        width: 50px;
+        height: 50px;
+    }
+    
+    .tool-btn i {
+        font-size: 16px;
+    }
+    
+    .tool-btn span {
+        font-size: 9px;
+    }
+}
+
+@media (max-width: 768px) {
+    .top-bar {
+        padding: 10px;
+        flex-direction: column;
+        gap: 10px;
+        max-height: none;
+    }
+    
+    .top-controls {
+        width: 100%;
+        justify-content: space-between;
+    }
+    
+    .study-info {
+        margin-left: 0;
+        min-width: auto;
+        width: 100%;
+    }
+    
+    .patient-info {
+        font-size: 12px;
+    }
+    
+    .right-panel {
+        width: 200px;
+    }
+}
+
+@media (max-width: 480px) {
+    .toolbar {
+        width: 60px;
+    }
+    
+    .tool-btn {
+        width: 40px;
+        height: 40px;
+        margin: 3px 0;
+    }
+    
+    .tool-btn i {
+        font-size: 14px;
+    }
+    
+    .tool-btn span {
+        font-size: 8px;
+    }
+    
+    .right-panel {
+        display: none; /* Hide on very small screens or make it collapsible */
+    }
 }
 
 .viewport {
@@ -46,6 +155,7 @@ body {
     position: relative;
     background: #000;
     overflow: hidden;
+    min-height: 0; /* Ensure proper flex sizing */
 }
 
 .right-panel {
@@ -91,6 +201,119 @@ body {
 
 .tool-btn span {
     font-size: 10px;
+}
+
+/* Dropdown Tools */
+.dropdown-tool {
+    position: relative;
+    width: 60px;
+}
+
+.dropdown-toggle {
+    position: relative;
+}
+
+.dropdown-arrow {
+    position: absolute;
+    right: 2px;
+    bottom: 2px;
+    font-size: 8px;
+    opacity: 0.7;
+}
+
+.dropdown-menu {
+    position: absolute;
+    left: 70px;
+    top: 0;
+    background: #1a1a1a;
+    border: 2px solid #00ff00;
+    border-radius: 8px;
+    min-width: 250px;
+    display: none;
+    z-index: 1000;
+    box-shadow: 0 4px 20px rgba(0, 255, 0, 0.2);
+}
+
+.dropdown-tool:hover .dropdown-menu,
+.dropdown-menu:hover {
+    display: block;
+}
+
+.dropdown-menu h4 {
+    margin: 0;
+    padding: 15px 20px;
+    border-bottom: 1px solid #333;
+    color: #00ff00;
+    font-size: 14px;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+}
+
+.dropdown-item {
+    padding: 12px 20px;
+    cursor: pointer;
+    transition: all 0.3s ease;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    font-size: 13px;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.dropdown-item:last-child {
+    border-bottom: none;
+}
+
+.dropdown-item:hover {
+    background: rgba(0, 255, 0, 0.1);
+    color: #00ff00;
+    padding-left: 25px;
+}
+
+.dropdown-item i {
+    width: 20px;
+    text-align: center;
+    opacity: 0.8;
+}
+
+.dropdown-item:hover i {
+    opacity: 1;
+    color: #00ff00;
+}
+
+/* Progress Overlay */
+.reconstruction-progress {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.8);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 9999;
+}
+
+.progress-content {
+    background: #1a1a1a;
+    border: 2px solid #00ff00;
+    border-radius: 12px;
+    padding: 40px;
+    text-align: center;
+    box-shadow: 0 0 30px rgba(0, 255, 0, 0.3);
+}
+
+.progress-content i {
+    font-size: 48px;
+    color: #00ff00;
+    margin-bottom: 20px;
+}
+
+.progress-content p {
+    font-size: 18px;
+    color: #fff;
+    margin: 0;
 }
 
 /* Canvas */
@@ -211,6 +434,27 @@ body {
 
 .secondary-btn:hover {
     background: #555;
+}
+
+.logout-btn {
+    background: #dc3545;
+    color: white;
+    padding: 10px 20px;
+    border: none;
+    border-radius: 6px;
+    cursor: pointer;
+    font-weight: 500;
+    font-size: 14px;
+    transition: all 0.3s ease;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.logout-btn:hover {
+    background: #c82333;
+    transform: translateY(-2px);
+    box-shadow: 0 4px 12px rgba(220, 53, 69, 0.3);
 }
 
 /* Preset Buttons */
@@ -629,17 +873,57 @@ body {
     max-height: 200px;
     overflow-y: auto;
     margin-top: 10px;
+    background: rgba(40, 40, 40, 0.8);
+    border-radius: 4px;
+    padding: 5px;
+}
+
+.measurements-list::-webkit-scrollbar {
+    width: 8px;
+}
+
+.measurements-list::-webkit-scrollbar-track {
+    background: rgba(255, 255, 255, 0.1);
+    border-radius: 4px;
+}
+
+.measurements-list::-webkit-scrollbar-thumb {
+    background: rgba(255, 255, 255, 0.3);
+    border-radius: 4px;
+}
+
+.measurements-list::-webkit-scrollbar-thumb:hover {
+    background: rgba(255, 255, 255, 0.5);
 }
 
 .measurement-item {
-    padding: 8px;
+    padding: 10px;
     margin-bottom: 5px;
-    background: #333;
+    background: rgba(50, 50, 50, 0.9);
     border-radius: 4px;
-    font-size: 12px;
+    font-size: 13px;
     display: flex;
     justify-content: space-between;
     align-items: center;
+    color: #fff;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    transition: all 0.2s ease;
+    cursor: pointer;
+}
+
+.measurement-item:hover {
+    background: rgba(60, 60, 60, 0.9);
+    border-color: rgba(255, 255, 255, 0.2);
+}
+
+.measurement-item.highlighted {
+    background: rgba(80, 80, 80, 0.9);
+    border-color: #4CAF50;
+}
+
+.measurement-item strong {
+    color: #4CAF50;
+    margin-right: 8px;
 }
 
 .measurement-item .delete-btn {
@@ -913,4 +1197,69 @@ body {
 .3d-status.error {
     background: #aa0000;
     color: #fff;
+}
+
+/* Clinical Information Section */
+.clinical-info-section {
+    background: #2a2a2a;
+    border: 1px solid #555;
+    border-radius: 5px;
+    margin-top: 10px;
+    overflow: hidden;
+}
+
+.clinical-info-header {
+    background: #333;
+    padding: 8px 12px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    cursor: pointer;
+}
+
+.clinical-info-header h4 {
+    margin: 0;
+    font-size: 14px;
+    color: #00ff00;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.btn-toggle {
+    background: none;
+    border: none;
+    color: #ccc;
+    cursor: pointer;
+    font-size: 12px;
+    padding: 2px;
+    border-radius: 3px;
+}
+
+.btn-toggle:hover {
+    color: #fff;
+    background: #555;
+}
+
+.clinical-info-content {
+    padding: 12px;
+    border-top: 1px solid #555;
+    max-height: 150px;
+    overflow-y: auto;
+}
+
+.clinical-info-content p {
+    margin: 0;
+    color: #ccc;
+    font-size: 13px;
+    line-height: 1.4;
+}
+
+.clinical-info-content.collapsed {
+    display: none;
+}
+
+.clinical-info.expanded {
+    background: #1a3a1a;
+    border-color: #00ff00;
 }

--- a/viewer/views.py
+++ b/viewer/views.py
@@ -985,7 +985,7 @@ def get_study_images(request, study_id):
     """Get all images for a study"""
     try:
         study = DicomStudy.objects.get(id=study_id)
-        images = DicomImage.objects.filter(series__study=study).order_by('series__series_number', 'instance_number')
+        images = DicomImage.objects.filter(series__study=study).order_by('series__series_number', 'image_number', 'instance_number')
         
         images_data = []
         for image in images:


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Resolves DICOM viewer displaying a blank screen by implementing robust error handling and correcting image loading sequence.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The issue was caused by a combination of silent JavaScript errors during study/image loading and an incorrect ordering of images fetched from the backend, leading to a blank viewer. This PR introduces comprehensive client-side error logging and on-canvas messages, corrects the image retrieval order in the API, and ensures the latest static assets are served, providing a functional and more debuggable DICOM viewing experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-219d3b2f-a9bb-4e96-9f4b-647f1897a1ee">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-219d3b2f-a9bb-4e96-9f4b-647f1897a1ee">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>