### PR TITLE
Fix dicom viewer not displaying images

### DIFF
--- a/static/css/dicom_viewer.css
+++ b/static/css/dicom_viewer.css
@@ -1263,3 +1263,14 @@ body {
     background: #1a3a1a;
     border-color: #00ff00;
 }
+
+/* Canvas specific styles */
+#dicom-canvas, .dicom-canvas {
+    display: block;
+    width: 100%;
+    height: 100%;
+    cursor: crosshair;
+    image-rendering: pixelated;
+    image-rendering: -moz-crisp-edges;
+    image-rendering: crisp-edges;
+}


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fix DICOM viewer not displaying images when redirected from the dashboard.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The issue was caused by a combination of factors: frontend timing where the study loaded before the canvas was ready, incorrect double-prefixing of image data URLs from the backend, and a lack of explicit CSS for the canvas visibility. This PR addresses these by adjusting JS initialization, correcting the image data format, adding canvas styling, and improving error handling for better debugging.

---
<a href="https://cursor.com/background-agent?bcId=bc-27b4163b-4f42-42a7-b499-c52ff25a3c58">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-27b4163b-4f42-42a7-b499-c52ff25a3c58">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>