### PR TITLE
Fix upload file number limit

### DIFF
--- a/noctisview/settings.py
+++ b/noctisview/settings.py
@@ -121,6 +121,8 @@ FILE_UPLOAD_HANDLERS = [
 # Maximum file upload size (100MB)
 DATA_UPLOAD_MAX_MEMORY_SIZE = 100 * 1024 * 1024
 FILE_UPLOAD_MAX_MEMORY_SIZE = 100 * 1024 * 1024
+DATA_UPLOAD_MAX_NUMBER_FIELDS = None  # Allow unlimited number of POST fields
+DATA_UPLOAD_MAX_NUMBER_FILES = None  # Allow unlimited number of uploaded files
 
 # Ensure media directories are created
 import os


### PR DESCRIPTION
Disable Django's file upload limits to allow large folder and file uploads.

---
<a href="https://cursor.com/background-agent?bcId=bc-547d8800-e4df-4aee-a88b-33302e25dea8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-547d8800-e4df-4aee-a88b-33302e25dea8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>