### PR TITLE
Configure dicom viewer admin interface

### DIFF
--- a/dicom_viewer/admin.py
+++ b/dicom_viewer/admin.py
@@ -1,0 +1,96 @@
+from django.contrib import admin
+from .models import DicomStudy, DicomSeries, DicomImage, Measurement, Annotation
+
+
+@admin.register(DicomStudy)
+class DicomStudyAdmin(admin.ModelAdmin):
+    list_display = ['patient_name', 'study_date', 'modality', 'series_count', 'total_images', 'created_at']
+    list_filter = ['modality', 'study_date', 'created_at']
+    search_fields = ['patient_name', 'patient_id', 'study_description']
+    readonly_fields = ['study_instance_uid', 'created_at', 'series_count', 'total_images']
+    
+    fieldsets = (
+        ('Patient Information', {
+            'fields': ('patient_name', 'patient_id')
+        }),
+        ('Study Information', {
+            'fields': ('study_instance_uid', 'study_date', 'study_time', 'study_description', 'modality', 'institution_name')
+        }),
+        ('System Information', {
+            'fields': ('uploaded_by', 'created_at', 'series_count', 'total_images')
+        }),
+    )
+
+
+@admin.register(DicomSeries)
+class DicomSeriesAdmin(admin.ModelAdmin):
+    list_display = ['__str__', 'study', 'modality', 'image_count', 'created_at']
+    list_filter = ['modality', 'created_at']
+    search_fields = ['series_description', 'study__patient_name']
+    readonly_fields = ['series_instance_uid', 'created_at', 'image_count']
+    
+    fieldsets = (
+        ('Series Information', {
+            'fields': ('study', 'series_instance_uid', 'series_number', 'series_description', 'modality', 'body_part_examined')
+        }),
+        ('System Information', {
+            'fields': ('created_at', 'image_count')
+        }),
+    )
+
+
+@admin.register(DicomImage)
+class DicomImageAdmin(admin.ModelAdmin):
+    list_display = ['__str__', 'series', 'rows', 'columns', 'window_width', 'window_center', 'created_at']
+    list_filter = ['created_at', 'series__modality']
+    search_fields = ['sop_instance_uid', 'series__series_description', 'series__study__patient_name']
+    readonly_fields = ['sop_instance_uid', 'created_at']
+    
+    fieldsets = (
+        ('Image Information', {
+            'fields': ('series', 'sop_instance_uid', 'instance_number', 'file_path')
+        }),
+        ('Image Properties', {
+            'fields': ('rows', 'columns', 'pixel_spacing_x', 'pixel_spacing_y', 'slice_thickness')
+        }),
+        ('Display Properties', {
+            'fields': ('window_width', 'window_center')
+        }),
+        ('System Information', {
+            'fields': ('created_at',)
+        }),
+    )
+
+
+@admin.register(Measurement)
+class MeasurementAdmin(admin.ModelAdmin):
+    list_display = ['__str__', 'image', 'measurement_type', 'created_by', 'created_at']
+    list_filter = ['measurement_type', 'unit', 'created_at']
+    search_fields = ['notes', 'image__series__study__patient_name']
+    readonly_fields = ['created_at']
+    
+    fieldsets = (
+        ('Measurement Information', {
+            'fields': ('image', 'measurement_type', 'coordinates', 'value', 'unit', 'notes')
+        }),
+        ('System Information', {
+            'fields': ('created_by', 'created_at')
+        }),
+    )
+
+
+@admin.register(Annotation)
+class AnnotationAdmin(admin.ModelAdmin):
+    list_display = ['__str__', 'image', 'x_coordinate', 'y_coordinate', 'created_by', 'created_at']
+    list_filter = ['created_at']
+    search_fields = ['text', 'image__series__study__patient_name']
+    readonly_fields = ['created_at']
+    
+    fieldsets = (
+        ('Annotation Information', {
+            'fields': ('image', 'x_coordinate', 'y_coordinate', 'text')
+        }),
+        ('System Information', {
+            'fields': ('created_by', 'created_at')
+        }),
+    )

--- a/dicom_viewer/models.py
+++ b/dicom_viewer/models.py
@@ -1,0 +1,210 @@
+from django.db import models
+from django.contrib.auth.models import User
+import json
+import os
+import pydicom
+from django.conf import settings
+from PIL import Image
+import numpy as np
+import io
+import base64
+
+
+class DicomStudy(models.Model):
+    """Model to represent a DICOM study"""
+    study_instance_uid = models.CharField(max_length=100, unique=True)
+    patient_name = models.CharField(max_length=200)
+    patient_id = models.CharField(max_length=100)
+    study_date = models.DateField(null=True, blank=True)
+    study_time = models.TimeField(null=True, blank=True)
+    study_description = models.TextField(blank=True)
+    modality = models.CharField(max_length=10)
+    institution_name = models.CharField(max_length=200, blank=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+    uploaded_by = models.ForeignKey(User, on_delete=models.CASCADE, null=True, blank=True)
+    
+    class Meta:
+        ordering = ['-created_at']
+    
+    def __str__(self):
+        return f"{self.patient_name} - {self.study_date} ({self.modality})"
+    
+    @property
+    def series_count(self):
+        return self.series.count()
+    
+    @property
+    def total_images(self):
+        return DicomImage.objects.filter(series__study=self).count()
+
+
+class DicomSeries(models.Model):
+    """Model to represent a DICOM series"""
+    study = models.ForeignKey(DicomStudy, related_name='series', on_delete=models.CASCADE)
+    series_instance_uid = models.CharField(max_length=100)
+    series_number = models.IntegerField(default=0)
+    series_description = models.CharField(max_length=200, blank=True)
+    modality = models.CharField(max_length=10)
+    body_part_examined = models.CharField(max_length=100, blank=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+    
+    class Meta:
+        ordering = ['series_number']
+        unique_together = ['study', 'series_instance_uid']
+    
+    def __str__(self):
+        return f"Series {self.series_number}: {self.series_description}"
+    
+    @property
+    def image_count(self):
+        return self.images.count()
+
+
+class DicomImage(models.Model):
+    """Model to represent individual DICOM images"""
+    series = models.ForeignKey(DicomSeries, related_name='images', on_delete=models.CASCADE)
+    sop_instance_uid = models.CharField(max_length=100)
+    instance_number = models.IntegerField(default=0)
+    file_path = models.FileField(upload_to='dicom_files/')
+    
+    # Image properties
+    rows = models.IntegerField(default=0)
+    columns = models.IntegerField(default=0)
+    pixel_spacing_x = models.FloatField(null=True, blank=True)
+    pixel_spacing_y = models.FloatField(null=True, blank=True)
+    slice_thickness = models.FloatField(null=True, blank=True)
+    window_width = models.FloatField(null=True, blank=True)
+    window_center = models.FloatField(null=True, blank=True)
+    
+    # Cached processed image
+    processed_image_cache = models.TextField(blank=True)  # Base64 encoded image
+    
+    created_at = models.DateTimeField(auto_now_add=True)
+    
+    class Meta:
+        ordering = ['instance_number']
+        unique_together = ['series', 'sop_instance_uid']
+    
+    def __str__(self):
+        return f"Image {self.instance_number}"
+    
+    def load_dicom_data(self):
+        """Load and return pydicom dataset"""
+        if self.file_path and os.path.exists(self.file_path.path):
+            try:
+                return pydicom.dcmread(self.file_path.path)
+            except Exception as e:
+                print(f"Error loading DICOM: {e}")
+                return None
+        return None
+    
+    def get_pixel_array(self):
+        """Get pixel array from DICOM file"""
+        dicom_data = self.load_dicom_data()
+        if dicom_data and hasattr(dicom_data, 'pixel_array'):
+            return dicom_data.pixel_array
+        return None
+    
+    def apply_windowing(self, pixel_array, window_width=None, window_level=None, inverted=False):
+        """Apply window/level to pixel array"""
+        if pixel_array is None:
+            return None
+        
+        # Use provided values or defaults from DICOM
+        ww = window_width if window_width is not None else (self.window_width or 400)
+        wl = window_level if window_level is not None else (self.window_center or 40)
+        
+        # Convert to float for calculations
+        image_data = pixel_array.astype(np.float32)
+        
+        # Apply window/level
+        min_val = wl - ww / 2
+        max_val = wl + ww / 2
+        
+        # Clip and normalize
+        image_data = np.clip(image_data, min_val, max_val)
+        image_data = (image_data - min_val) / (max_val - min_val) * 255
+        
+        if inverted:
+            image_data = 255 - image_data
+        
+        return image_data.astype(np.uint8)
+    
+    def get_processed_image_base64(self, window_width=None, window_level=None, inverted=False):
+        """Get processed image as base64 string"""
+        pixel_array = self.get_pixel_array()
+        if pixel_array is None:
+            return None
+        
+        processed_array = self.apply_windowing(pixel_array, window_width, window_level, inverted)
+        
+        # Convert to PIL Image
+        pil_image = Image.fromarray(processed_array, mode='L')
+        
+        # Convert to base64
+        buffer = io.BytesIO()
+        pil_image.save(buffer, format='PNG')
+        image_base64 = base64.b64encode(buffer.getvalue()).decode()
+        
+        return f"data:image/png;base64,{image_base64}"
+    
+    def save_dicom_metadata(self):
+        """Extract and save metadata from DICOM file"""
+        dicom_data = self.load_dicom_data()
+        if not dicom_data:
+            return
+        
+        # Update image properties
+        self.rows = getattr(dicom_data, 'Rows', 0)
+        self.columns = getattr(dicom_data, 'Columns', 0)
+        
+        pixel_spacing = getattr(dicom_data, 'PixelSpacing', None)
+        if pixel_spacing and len(pixel_spacing) >= 2:
+            self.pixel_spacing_x = float(pixel_spacing[0])
+            self.pixel_spacing_y = float(pixel_spacing[1])
+        
+        self.slice_thickness = getattr(dicom_data, 'SliceThickness', None)
+        self.window_width = getattr(dicom_data, 'WindowWidth', None)
+        self.window_center = getattr(dicom_data, 'WindowCenter', None)
+        
+        self.save()
+
+
+class Measurement(models.Model):
+    """Model to store user measurements"""
+    MEASUREMENT_TYPES = [
+        ('line', 'Line Measurement'),
+        ('angle', 'Angle Measurement'),
+        ('area', 'Area Measurement'),
+    ]
+    
+    image = models.ForeignKey(DicomImage, related_name='measurements', on_delete=models.CASCADE)
+    measurement_type = models.CharField(max_length=10, choices=MEASUREMENT_TYPES, default='line')
+    coordinates = models.JSONField()  # Store coordinates as JSON
+    value = models.FloatField()  # Measurement value (distance, angle, area)
+    unit = models.CharField(max_length=10, default='px')  # px, mm, cm
+    notes = models.TextField(blank=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+    created_by = models.ForeignKey(User, on_delete=models.CASCADE, null=True, blank=True)
+    
+    class Meta:
+        ordering = ['-created_at']
+    
+    def __str__(self):
+        return f"{self.measurement_type}: {self.value} {self.unit}"
+
+
+class Annotation(models.Model):
+    """Model to store user annotations"""
+    image = models.ForeignKey(DicomImage, related_name='annotations', on_delete=models.CASCADE)
+    x_coordinate = models.FloatField()
+    y_coordinate = models.FloatField()
+    text = models.TextField()
+    created_at = models.DateTimeField(auto_now_add=True)
+    created_by = models.ForeignKey(User, on_delete=models.CASCADE, null=True, blank=True)
+    
+    class Meta:
+        ordering = ['-created_at']
+    
+    def __str__(self):
+        return f"Annotation: {self.text[:50]}"


### PR DESCRIPTION
Separate DICOM viewer Django admin and model definitions into dedicated files.

The original input combined admin and model code into a single block with a syntax error. This PR correctly splits them into `dicom_viewer/admin.py` and `dicom_viewer/models.py` for proper project structure and functionality.

---
<a href="https://cursor.com/background-agent?bcId=bc-e9f3cea4-1b21-4524-97d2-5ffeff096200">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e9f3cea4-1b21-4524-97d2-5ffeff096200">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>