### PR TITLE
Enhance dicom viewer image quality and ui

### DIFF
--- a/static/css/dicom_viewer.css
+++ b/static/css/dicom_viewer.css
@@ -2293,3 +2293,13 @@ body {
     box-shadow: 0 0 15px rgba(0, 255, 0, 0.3);
 }
 
+/* Hide removed tools and panels */
+button.tool-btn[data-tool="folder"],
+button.tool-btn[data-tool="navigator"],
+button.tool-btn[data-tool="enhance"],
+#image-navigator,
+#enhancement-panel,
+#density-processing-section {
+    display: none !important;
+}
+

--- a/static/js/dicom_viewer.js
+++ b/static/js/dicom_viewer.js
@@ -22,8 +22,9 @@ class DicomViewer {
         this.currentImage = null;
         
         // Display parameters optimized for medical imaging
-        this.windowWidth = 1500;  // Wider window for better tissue differentiation
-        this.windowLevel = -600;  // Lung window setting for better contrast
+        // Set default window/level for soft-tissue viewing to avoid over-bright display
+        this.windowWidth = 400;   // Soft-tissue window width
+        this.windowLevel = 40;    // Soft-tissue window level
         this.zoomFactor = 1.0;
         this.panX = 0;
         this.panY = 0;
@@ -161,11 +162,12 @@ class DicomViewer {
         // Initialize enhanced rendering parameters for optimal medical imaging
         this.renderingOptions = {
             preserveSharpness: true,
-            enhanceDensityContrast: true,
+            // Disable density contrast filter by default – it was over-brightening images
+            enhanceDensityContrast: false,
             antialiasing: false, // Disable for pixel-perfect medical imaging
             subpixelRendering: true,
             highQualityMode: true,
-            densityEnhancement: true,
+            densityEnhancement: false,
             contrastOptimization: 'medical',
             imageSmoothingEnabled: false // Preserve medical image sharpness
         };

--- a/templates/dicom_viewer/viewer.html
+++ b/templates/dicom_viewer/viewer.html
@@ -781,8 +781,8 @@
         <!-- Right Panel -->
         <div class="right-panel">
             <div class="panel-content">
-                <!-- Enhanced Controls -->
-                <div class="panel-section">
+                <!-- Enhanced Density Processing panel hidden -->
+                <div class="panel-section" id="density-processing-section" style="display: none;">
                     <h3 class="section-title">Enhanced Density Processing</h3>
                     <div class="enhanced-controls">
                         <div class="control-group">


### PR DESCRIPTION
Adjust default DICOM window/level and disable automatic enhancement filters to resolve over-bright images and simplify the viewer UI.

---
<a href="https://cursor.com/background-agent?bcId=bc-06386d3a-dee0-4c56-9dfd-effd2b60dd62">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-06386d3a-dee0-4c56-9dfd-effd2b60dd62">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>