### PR TITLE
Fix image loading internal server error

### DIFF
--- a/IMAGE_LOADING_FIX_SUMMARY.md
+++ b/IMAGE_LOADING_FIX_SUMMARY.md
@@ -1,0 +1,50 @@
+# Image Loading Fix Summary
+
+## Issue
+The DICOM viewer was returning "500 Internal Server Error" when trying to load images. The error occurred specifically for test images (IDs 5, 6, 7) that had file paths pointing to non-existent files (`/test/image_1.dcm`, etc.) but had cached image data in the database.
+
+## Root Cause
+The `get_enhanced_processed_image_base64_original` method was attempting to load pixel data from DICOM files even when cached image data was available. For test images with non-existent file paths, this caused the method to fail with a file not found error.
+
+## Solution
+Modified three methods in `viewer/models.py` to check for cached data first before attempting file operations:
+
+### 1. `get_enhanced_processed_image_base64_original` (line ~515)
+Added a check for cached data at the beginning of the method:
+```python
+# Check for cached data first to avoid file access errors
+cached_data = self.get_fallback_image_data()
+if cached_data:
+    print(f"Using cached data in original method for image {self.id}")
+    return cached_data
+```
+
+### 2. `load_dicom_data` (line ~173)
+Added early return if cached data exists:
+```python
+# Check for cached data first (for test images)
+if self.processed_image_cache:
+    print(f"Image {self.id} has cached data, skipping file load")
+    return None
+```
+
+### 3. `get_pixel_array` (line ~236)
+Added check to avoid loading pixel array for cached images:
+```python
+# If we have cached data, we don't need pixel array
+if self.processed_image_cache:
+    print(f"Image {self.id} has cached data, no pixel array needed")
+    return None
+```
+
+## Benefits
+1. **Fixes 500 errors**: Test images with cached data now load successfully
+2. **Performance improvement**: Avoids unnecessary file I/O for cached images
+3. **Better error handling**: Gracefully handles missing files when cached data is available
+4. **Maintains compatibility**: Real DICOM files continue to work as before
+
+## Verification
+The fix can be verified by:
+1. Accessing images with IDs 5, 6, or 7 through the viewer API
+2. These images should now return their cached base64 image data instead of failing
+3. Real DICOM files (IDs 1, 3, 4) continue to load from disk as expected


### PR DESCRIPTION
Fix 500 Internal Server Error for images with cached data by prioritizing cache over file access.

---
<a href="https://cursor.com/background-agent?bcId=bc-6c82dd7a-286d-450d-a346-cad53a12fe87">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6c82dd7a-286d-450d-a346-cad53a12fe87">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>