### PR TITLE
Debug DICOM image loading errors

### DIFF
--- a/IMAGE_LOADING_ERROR_FIX_SUMMARY.md
+++ b/IMAGE_LOADING_ERROR_FIX_SUMMARY.md
@@ -1,0 +1,146 @@
+# Image Loading Error Fix Summary
+
+## Problem Description
+
+The DICOM viewer was experiencing a console error:
+```
+data:image/png;base…:1   Failed to load resource: net::ERR_INVALID_URL
+dicom_viewer_fixed.js:422  Error refreshing image: Event
+```
+
+This error occurred when the JavaScript tried to create a data URL with invalid or empty base64 data, resulting in an invalid URL like `data:image/png;base64,` (with no base64 content).
+
+## Root Cause Analysis
+
+1. **Invalid Base64 Data**: The Django backend was sometimes returning `None` or empty strings from the `get_enhanced_processed_image_base64()` method
+2. **Poor Error Handling**: The JavaScript code didn't validate the base64 data before attempting to create the data URL
+3. **Fallback Failures**: The fallback mechanisms in the Django model could also return `None` in some edge cases
+
+## Fixes Implemented
+
+### 1. JavaScript Error Handling (`static/js/dicom_viewer_fixed.js`)
+
+#### Enhanced `displayProcessedImage()` Method
+- Added validation for base64 data before processing
+- Added cleaning of base64 data to handle cases where data URL prefix is already present
+- Added proper base64 format validation using regex
+- Enhanced error handling with user-friendly error messages
+
+#### Enhanced `refreshCurrentImage()` Method
+- Added validation for empty or null image data from server
+- Added try-catch blocks around image display operations
+- Added fallback to error placeholder when image loading fails
+
+#### New `showErrorPlaceholder()` Method
+- Displays a user-friendly error message when image loading fails
+- Shows a visual error icon and helpful text
+- Provides guidance to users on what to do next
+
+### 2. Django Backend Improvements (`viewer/models.py`)
+
+#### Enhanced `get_enhanced_processed_image_base64()` Method
+- Added validation to ensure the method never returns `None`
+- Added absolute fallback to return a minimal valid PNG image
+- Improved error handling in the fallback chain
+
+#### Enhanced `generate_synthetic_image()` Method
+- Added multiple fallback layers to ensure it never returns `None`
+- Added hardcoded minimal PNG as absolute last resort
+- Improved error handling and logging
+
+### 3. API Response Improvements (`viewer/views.py`)
+
+#### Enhanced `get_image_data()` View
+- Added validation for empty or null base64 data
+- Improved error response format with structured error information
+- Added better logging for debugging image processing issues
+- Ensured consistent response format even in error cases
+
+## Code Changes Summary
+
+### JavaScript Changes
+```javascript
+// Added validation in displayProcessedImage()
+if (!base64Data || typeof base64Data !== 'string' || base64Data.trim() === '') {
+    console.error('Invalid or empty base64 data received');
+    this.notyf.error('Invalid image data received from server');
+    reject(new Error('Invalid base64 data'));
+    return;
+}
+
+// Added base64 format validation
+if (!/^[A-Za-z0-9+/]*={0,2}$/.test(cleanBase64)) {
+    console.error('Invalid base64 format');
+    this.notyf.error('Invalid image data format');
+    reject(new Error('Invalid base64 format'));
+    return;
+}
+```
+
+### Django Model Changes
+```python
+# Enhanced fallback in generate_synthetic_image()
+except Exception as e:
+    print(f"Failed to generate synthetic image: {e}")
+    # Return a minimal valid base64 image as absolute last resort
+    try:
+        from PIL import Image
+        import io
+        import base64
+        
+        # Create a simple 1x1 black pixel as absolute fallback
+        img = Image.new('L', (1, 1), 0)
+        buffer = io.BytesIO()
+        img.save(buffer, format='PNG')
+        buffer.seek(0)
+        image_base64 = base64.b64encode(buffer.getvalue()).decode('utf-8')
+        return f"data:image/png;base64,{image_base64}"
+    except:
+        # If even this fails, return a hardcoded minimal PNG
+        return "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg=="
+```
+
+### API View Changes
+```python
+# Enhanced validation in get_image_data()
+if image_base64 and image_base64.strip():
+    # Process valid image data
+    return Response({'image_data': image_base64, ...})
+else:
+    # Handle invalid data with proper error response
+    return Response({
+        'error': 'Could not process image - file may be missing or corrupted',
+        'image_data': None,
+        'metadata': {'error': True, 'message': 'Image processing failed'}
+    }, status=404)
+```
+
+## Benefits of the Fix
+
+1. **Eliminates Console Errors**: The invalid URL error will no longer occur
+2. **Better User Experience**: Users see helpful error messages instead of blank screens
+3. **Improved Reliability**: Multiple fallback layers ensure the viewer always shows something
+4. **Better Debugging**: Enhanced logging helps identify the root cause of image loading issues
+5. **Graceful Degradation**: The system continues to work even when image processing fails
+
+## Testing Recommendations
+
+1. **Test with Missing Files**: Verify that the viewer handles missing DICOM files gracefully
+2. **Test with Corrupted Data**: Verify that corrupted image data is handled properly
+3. **Test Network Issues**: Verify that network failures are handled gracefully
+4. **Test Edge Cases**: Verify that empty or null responses from the server are handled
+
+## Future Improvements
+
+1. **Image Caching**: Implement client-side caching to reduce server load
+2. **Progressive Loading**: Add loading indicators for better user experience
+3. **Retry Logic**: Add automatic retry for failed image loads
+4. **Image Compression**: Implement adaptive image compression based on network conditions
+
+## Files Modified
+
+1. `static/js/dicom_viewer_fixed.js` - Enhanced error handling and validation
+2. `viewer/models.py` - Improved fallback mechanisms and error handling
+3. `viewer/views.py` - Enhanced API response validation and error handling
+
+The fix ensures that the DICOM viewer will no longer show the invalid URL error and will provide a better user experience when image loading issues occur.

--- a/test_image_loading_fix.py
+++ b/test_image_loading_fix.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""
+Test script to verify image loading fixes
+"""
+
+import os
+import sys
+import django
+
+# Add the project directory to Python path
+sys.path.append('/workspace')
+
+# Set up Django environment
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'noctisview.settings')
+django.setup()
+
+from viewer.models import DicomImage
+from django.http import HttpRequest
+from viewer.views import get_image_data
+from rest_framework.test import APIRequestFactory
+import json
+
+def test_image_loading():
+    """Test image loading functionality"""
+    print("Testing image loading fixes...")
+    
+    # Get the first available image
+    try:
+        image = DicomImage.objects.first()
+        if not image:
+            print("No images found in database")
+            return False
+        
+        print(f"Testing with image ID: {image.id}")
+        
+        # Test the enhanced processing method directly
+        print("Testing get_enhanced_processed_image_base64...")
+        result = image.get_enhanced_processed_image_base64()
+        
+        if result and result.strip():
+            print(f"✓ Enhanced processing returned valid data (length: {len(result)})")
+            if result.startswith('data:image/png;base64,'):
+                print("✓ Data URL format is correct")
+            else:
+                print("⚠ Data URL format may be incorrect")
+        else:
+            print("✗ Enhanced processing returned empty or None data")
+            return False
+        
+        # Test the API endpoint
+        print("\nTesting API endpoint...")
+        factory = APIRequestFactory()
+        request = factory.get(f'/viewer/api/get-image-data/{image.id}/')
+        
+        # Mock the request user and other attributes
+        request.user = None
+        request.GET = {}
+        
+        try:
+            response = get_image_data(request, image.id)
+            print(f"✓ API endpoint returned status: {response.status_code}")
+            
+            if response.status_code == 200:
+                data = response.data
+                if 'image_data' in data and data['image_data']:
+                    print(f"✓ API returned valid image data (length: {len(data['image_data'])})")
+                    return True
+                else:
+                    print("✗ API returned empty image data")
+                    return False
+            else:
+                print(f"✗ API returned error status: {response.status_code}")
+                if hasattr(response, 'data'):
+                    print(f"Error details: {response.data}")
+                return False
+                
+        except Exception as e:
+            print(f"✗ API endpoint failed: {e}")
+            return False
+            
+    except Exception as e:
+        print(f"✗ Test failed: {e}")
+        import traceback
+        traceback.print_exc()
+        return False
+
+def test_synthetic_image_generation():
+    """Test synthetic image generation"""
+    print("\nTesting synthetic image generation...")
+    
+    try:
+        image = DicomImage.objects.first()
+        if not image:
+            print("No images found for testing")
+            return False
+        
+        result = image.generate_synthetic_image()
+        
+        if result and result.strip():
+            print(f"✓ Synthetic image generation successful (length: {len(result)})")
+            if result.startswith('data:image/png;base64,'):
+                print("✓ Synthetic image has correct data URL format")
+                return True
+            else:
+                print("⚠ Synthetic image format may be incorrect")
+                return False
+        else:
+            print("✗ Synthetic image generation failed")
+            return False
+            
+    except Exception as e:
+        print(f"✗ Synthetic image test failed: {e}")
+        return False
+
+if __name__ == "__main__":
+    print("=== Image Loading Fix Test ===")
+    
+    success1 = test_image_loading()
+    success2 = test_synthetic_image_generation()
+    
+    print("\n=== Test Results ===")
+    print(f"Image Loading: {'✓ PASS' if success1 else '✗ FAIL'}")
+    print(f"Synthetic Generation: {'✓ PASS' if success2 else '✗ FAIL'}")
+    
+    if success1 and success2:
+        print("\n🎉 All tests passed! Image loading should work correctly.")
+    else:
+        print("\n❌ Some tests failed. Please check the implementation.")


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fixes DICOM viewer image loading error by adding robust frontend validation and backend fallbacks.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The `net::ERR_INVALID_URL` error in the DICOM viewer was caused by the JavaScript attempting to create a data URL from `None` or empty base64 data received from the Django backend. This PR introduces comprehensive error handling and data validation in `dicom_viewer_fixed.js` to gracefully handle invalid image data. Concurrently, `viewer/models.py` and `viewer/views.py` are enhanced with multiple fallback mechanisms and stricter data return policies to ensure a valid base64 image (even a minimal placeholder) is always provided, preventing the invalid URL issue and improving user experience with clear error messages.

---
<a href="https://cursor.com/background-agent?bcId=bc-8befcd2a-1352-478c-b9a9-b20d2ba16d93">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8befcd2a-1352-478c-b9a9-b20d2ba16d93">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>